### PR TITLE
update devices json

### DIFF
--- a/supported-devices/devices.json
+++ b/supported-devices/devices.json
@@ -7,14 +7,18 @@
                 "device": [
                     "HP Pavilion Chromebook 14"
                 ],
-                "boardname": "BUTTERFLY",
+                "boardname": [
+                    "BUTTERFLY"
+                ],
                 "wpMethod": "<a href=\"/images/wp/Butterfly_wp_switch.jpg\" class=\"internal\" title=\"Butterfly_wp_switch.jpg\" target=\"_blank\">switch</a>"
             },
             {
                 "device": [
                     "Google Chromebook Pixel (2013)"
                 ],
-                "boardname": "LINK",
+                "boardname": [
+                    "LINK"
+                ],
                 "rwLegacy": null,
                 "wpMethod": "<a href=\"/images/wp/Link_wp_screw.jpg\" class=\"internal\" title=\"Link_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
@@ -22,28 +26,36 @@
                 "device": [
                     "Samsung Chromebook Series 5 550"
                 ],
-                "boardname": "LUMPY",
+                "boardname": [
+                    "LUMPY"
+                ],
                 "wpMethod": "<a href=\"/images/wp/Lumpy_wp_jumper.jpg\" class=\"internal\" title=\"Lumpy_wp_jumper.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Acer C7/C710 Chromebook"
                 ],
-                "boardname": "PARROT",
+                "boardname": [
+                    "PARROT"
+                ],
                 "wpMethod": "<a href=\"/images/wp/Parrot_wp_jumper.jpg\" class=\"internal\" title=\"Parrot_wp_jumper.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Lenovo Thinkpad X131e Chromebook"
                 ],
-                "boardname": "STOUT",
+                "boardname": [
+                    "STOUT"
+                ],
                 "wpMethod": "<a href=\"/images/wp/stout_wp.jpg\" class=\"internal\" title=\"stout wp.jpg\" target=\"_blank\">switch</a>"
             },
             {
                 "device": [
                     "Samsung Chromebox Series 3"
                 ],
-                "boardname": "STUMPY",
+                "boardname": [
+                    "STUMPY"
+                ],
                 "wpMethod": "screw"
             }
         ]
@@ -57,63 +69,81 @@
                 "device": [
                     "HP Chromebook 14"
                 ],
-                "boardname": "FALCO",
+                "boardname": [
+                    "FALCO"
+                ],
                 "wpMethod": "screw"
             },
             {
                 "device": [
                     "Toshiba Chromebook 13 (CB30)"
                 ],
-                "boardname": "LEON",
+                "boardname": [
+                    "LEON"
+                ],
                 "wpMethod": "<a href=\"/images/wp/Leon_wp_screw.jpg\" class=\"internal\" title=\"Leon_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Acer Chromebox CXI"
                 ],
-                "boardname": "MCCLOUD",
+                "boardname": [
+                    "MCCLOUD"
+                ],
                 "wpMethod": "<a href=\"/images/wp/mccloud_wp.jpg\" class=\"internal\" title=\"mccloud_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "LG Chromebase 22"
                 ],
-                "boardname": "MONROE",
+                "boardname": [
+                    "MONROE"
+                ],
                 "wpMethod": "screw"
             },
             {
                 "device": [
                     "Asus Chromebox CN60"
                 ],
-                "boardname": "PANTHER",
+                "boardname": [
+                    "PANTHER"
+                ],
                 "wpMethod": "<a href=\"/images/wp/panther_wp.jpg\" class=\"internal\" title=\"panther_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Acer C720/C720P Chromebook"
                 ],
-                "boardname": "PEPPY",
+                "boardname": [
+                    "PEPPY"
+                ],
                 "wpMethod": "<a href=\"/images/wp/Peppy_wp_screw.jpg\" class=\"internal\" title=\"Peppy_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Dell Chromebox 3010"
                 ],
-                "boardname": "TRICKY",
+                "boardname": [
+                    "TRICKY"
+                ],
                 "wpMethod": "<a href=\"/images/wp/panther_wp.jpg\" class=\"internal\" title=\"panther_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Dell Chromebook 11 (CB1C13)"
                 ],
-                "boardname": "WOLF",
+                "boardname": [
+                    "WOLF"
+                ],
                 "wpMethod": "<a href=\"/images/wp/Wolf_wp_screw.jpg\" class=\"internal\" title=\"Wolf_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "HP Chromebox CB1 / G1"
                 ],
-                "boardname": "ZAKO",
+                "boardname": [
+                    "ZAKO"
+                ],
                 "wpMethod": "<a href=\"/images/wp/panther_wp.jpg\" class=\"internal\" title=\"panther_wp.jpg\" target=\"_blank\">screw</a>"
             }
         ]
@@ -125,63 +155,83 @@
         "devices": [
             {
                 "device": [
+                    "Acer C740 Chromebook"
+                ],
+                "boardname": [
+                    "AURON_PAINE",
+                    "PAINE"
+                ]
+            },
+            {
+                "device": [
+                    "Acer C910 Chromebook (CB5-571)"
+                ],
+                "boardname": [
+                    "AURON_YUNA",
+                    "YUNA"
+                ]
+            },
+            {
+                "device": [
                     "Acer Chromebase 24"
                 ],
-                "boardname": "BUDDY",
+                "boardname": [
+                    "BUDDY"
+                ],
                 "wpMethod": "<a href=\"/images/wp/Buddy_wp_screw.jpg\" class=\"internal\" title=\"Buddy_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Toshiba Chromebook 2 (2015)"
                 ],
-                "boardname": "GANDOF",
+                "boardname": [
+                    "GANDOF"
+                ],
                 "wpMethod": "screw"
             },
             {
                 "device": [
                     "Asus Chromebox 2 (CN62)"
                 ],
-                "boardname": "GUADO",
+                "boardname": [
+                    "GUADO"
+                ],
                 "wpMethod": "<a href=\"/images/wp/panther_wp.jpg\" class=\"internal\" title=\"panther_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Dell Chromebook 13 7310"
                 ],
-                "boardname": "LULU"
-            },
-            {
-                "device": [
-                    "Acer C740 Chromebook"
-                ],
-                "boardname": "PAINE"
+                "boardname": [
+                    "LULU"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebox CXI2"
                 ],
-                "boardname": "RIKKU",
+                "boardname": [
+                    "RIKKU"
+                ],
                 "wpMethod": "<a href=\"/images/wp/mccloud_wp.jpg\" class=\"internal\" title=\"mccloud_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Google Chromebook Pixel (2015)"
                 ],
-                "boardname": "SAMUS",
+                "boardname": [
+                    "SAMUS"
+                ],
                 "wpMethod": "<a href=\"/images/wp/Samus_wp_screw.jpg\" class=\"internal\" title=\"Samus_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Lenovo ThinkCentre Chromebox"
                 ],
-                "boardname": "TIDUS",
-                "wpMethod": "<a href=\"/images/wp/tidus_wp.jpg\" class=\"internal\" title=\"tidus_wp.jpg\" target=\"_blank\">screw</a>"
-            },
-            {
-                "device": [
-                    "Acer C910 Chromebook (CB5-571)"
+                "boardname": [
+                    "TIDUS"
                 ],
-                "boardname": "YUNA"
+                "wpMethod": "<a href=\"/images/wp/tidus_wp.jpg\" class=\"internal\" title=\"tidus_wp.jpg\" target=\"_blank\">screw</a>"
             }
         ]
     },
@@ -194,94 +244,124 @@
                 "device": [
                     "Acer Chromebook 15 (CB3-531)"
                 ],
-                "boardname": "BANJO"
+                "boardname": [
+                    "BANJO"
+                ]
             },
             {
                 "device": [
                     "Dell Chromebook 11 (3120)"
                 ],
-                "boardname": "CANDY"
+                "boardname": [
+                    "CANDY"
+                ]
             },
             {
                 "device": [
                     "Lenovo N20/N20P Chromebook"
                 ],
-                "boardname": "CLAPPER"
+                "boardname": [
+                    "CLAPPER"
+                ]
             },
             {
                 "device": [
                     "CTL N6 Education Chromebook",
                     "Lenovo N21 Chromebook"
                 ],
-                "boardname": "ENGUARDE"
+                "boardname": [
+                    "ENGUARDE"
+                ]
             },
             {
                 "device": [
                     "Lenovo ThinkPad 11e/Yoga Chromebook"
                 ],
-                "boardname": "GLIMMER"
+                "boardname": [
+                    "GLIMMER"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 11 (CB3-111/131, C730, C730E, C735)"
                 ],
-                "boardname": "GNAWTY",
+                "boardname": [
+                    "GNAWTY"
+                ],
                 "wpMethod": "<a href=\"/images/wp/gnawty_wp.jpg\" class=\"internal\" title=\"gnawty_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Haier Chromebook G2"
                 ],
-                "boardname": "HELI"
+                "boardname": [
+                    "HELI"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 11 G3/G4",
                     "HP Chromebook 14 G4"
                 ],
-                "boardname": "KIP"
+                "boardname": [
+                    "KIP"
+                ]
             },
             {
                 "device": [
                     "AOpen Chromebox Commercial"
                 ],
-                "boardname": "NINJA"
+                "boardname": [
+                    "NINJA"
+                ]
             },
             {
                 "device": [
                     "Lenovo Ideapad 100S Chromebook"
                 ],
-                "boardname": "ORCO"
+                "boardname": [
+                    "ORCO"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook C300"
                 ],
-                "boardname": "QUAWKS"
+                "boardname": [
+                    "QUAWKS"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook C200"
                 ],
-                "boardname": "SQUAWKS"
+                "boardname": [
+                    "SQUAWKS"
+                ]
             },
             {
                 "device": [
                     "AOpen Chromebase Commercial"
                 ],
-                "boardname": "SUMO"
+                "boardname": [
+                    "SUMO"
+                ]
             },
             {
                 "device": [
                     "Toshiba Chromebook 2 (2014)"
                 ],
-                "boardname": "SWANKY"
+                "boardname": [
+                    "SWANKY"
+                ]
             },
             {
                 "device": [
                     "Samsung Chromebook 2 (XE500C12)"
                 ],
-                "boardname": "WINKY"
+                "boardname": [
+                    "WINKY"
+                ]
             }
         ]
     },
@@ -294,40 +374,52 @@
                 "device": [
                     "Acer Chromebook 15 (CB3-532)"
                 ],
-                "boardname": "BANON",
+                "boardname": [
+                    "BANON"
+                ],
                 "wpMethod": "<a href=\"/images/wp/Banon_wp.jpg\" class=\"internal\" title=\"Banon wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Samsung Chromebook 3"
                 ],
-                "boardname": "CELES"
+                "boardname": [
+                    "CELES"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook R11 (C738T, CB5-132T)"
                 ],
-                "boardname": "CYAN",
+                "boardname": [
+                    "CYAN"
+                ],
                 "wpMethod": "<a href=\"/images/wp/cyan_wp.jpg\" class=\"internal\" title=\"cyan_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Acer Chromebook 14 (CB3-431)"
                 ],
-                "boardname": "EDGAR",
+                "boardname": [
+                    "EDGAR"
+                ],
                 "wpMethod": "<a href=\"/images/wp/Edgar_wp.jpg\" class=\"internal\" title=\"Edgar wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Dell Chromebook 11 3180/3189"
                 ],
-                "boardname": "KEFKA"
+                "boardname": [
+                    "KEFKA"
+                ]
             },
             {
                 "device": [
                     "Lenovo N22/N23/N42 Chromebook"
                 ],
-                "boardname": "REKS"
+                "boardname": [
+                    "REKS"
+                ]
             },
             {
                 "device": [
@@ -339,14 +431,18 @@
                     "Mecer V2 Chromebook",
                     "Positivo Chromebook C216B"
                 ],
-                "boardname": "RELM",
+                "boardname": [
+                    "RELM"
+                ],
                 "wpMethod": "<a href=\"/images/wp/C731_wp.jpg\" class=\"internal\" title=\"C731 wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "HP Chromebook 11 G5"
                 ],
-                "boardname": "SETZER",
+                "boardname": [
+                    "SETZER"
+                ],
                 "wpMethod": "<a href=\"/images/wp/setzer_wp.png\" class=\"internal\" title=\"setzer_wp.png\" target=\"_blank\">screw</a>"
             },
             {
@@ -354,14 +450,18 @@
                     "Asus Chromebook C202S/C202SA",
                     "Asus Chromebook C300SA/C301SA"
                 ],
-                "boardname": "TERRA",
+                "boardname": [
+                    "TERRA"
+                ],
                 "wpMethod": "<a href=\"/images/wp/C202sa_wp.jpg\" class=\"internal\" title=\"C202sa wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Lenovo ThinkPad 11e/Yoga Chromebook (G3)"
                 ],
-                "boardname": "ULTIMA"
+                "boardname": [
+                    "ULTIMA"
+                ]
             },
             {
                 "device": [
@@ -373,7 +473,9 @@
                     "Prowise Chromebook Proline",
                     "Viglen Chromebook 360"
                 ],
-                "boardname": "WIZPIG"
+                "boardname": [
+                    "WIZPIG"
+                ]
             }
         ]
     },
@@ -386,39 +488,51 @@
                 "device": [
                     "Dell Chromebook 13 3380"
                 ],
-                "boardname": "ASUKA"
+                "boardname": [
+                    "ASUKA"
+                ]
             },
             {
                 "device": [
                     "Samsung Chromebook Pro"
                 ],
-                "boardname": "CAROLINE",
+                "boardname": [
+                    "CAROLINE"
+                ],
                 "wpMethod": "<a href=\"/images/wp/Caroline_wp.jpg\" class=\"internal\" title=\"Caroline_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Asus Chromebook C302CA"
                 ],
-                "boardname": "CAVE"
+                "boardname": [
+                    "CAVE"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 13 G1"
                 ],
-                "boardname": "CHELL"
+                "boardname": [
+                    "CHELL"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 14 for Work",
                     "Acer Chromebook 11 (C771/C771T)"
                 ],
-                "boardname": "LARS"
+                "boardname": [
+                    "LARS"
+                ]
             },
             {
                 "device": [
                     "Lenovo Thinkpad 13 Chromebook"
                 ],
-                "boardname": "SENTRY"
+                "boardname": [
+                    "SENTRY"
+                ]
             }
         ]
     },
@@ -431,21 +545,27 @@
                 "device": [
                     "Acer Chromebook 11 (C732)"
                 ],
-                "boardname": "ASTRONAUT"
+                "boardname": [
+                    "ASTRONAUT"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook C223NA",
                     "ASUS Chromebook CX1100CNA"
                 ],
-                "boardname": "BABYMEGA"
+                "boardname": [
+                    "BABYMEGA"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook C523NA",
                     "ASUS Chromebook CX1500CNA"
                 ],
-                "boardname": "BABYTIGER"
+                "boardname": [
+                    "BABYTIGER"
+                ]
             },
             {
                 "device": [
@@ -456,87 +576,115 @@
                     "Positivo Chromebook N2110/N2112",
                     "Viglen Chromebook 360C"
                 ],
-                "boardname": "BLACKTIP"
+                "boardname": [
+                    "BLACKTIP"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 15 (CB315)"
                 ],
-                "boardname": "BLUE"
+                "boardname": [
+                    "BLUE"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 15 (CP315)"
                 ],
-                "boardname": "BRUCE"
+                "boardname": [
+                    "BRUCE"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 514 (CB514-1H, CB514-1HT)"
                 ],
-                "boardname": "EPAULETTE"
+                "boardname": [
+                    "EPAULETTE"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 11 (CP311-1H, CP311-1HN)"
                 ],
-                "boardname": "LAVA"
+                "boardname": [
+                    "LAVA"
+                ]
             },
             {
                 "device": [
                     "Dell Chromebook 11 5190"
                 ],
-                "boardname": "NASHER"
+                "boardname": [
+                    "NASHER"
+                ]
             },
             {
                 "device": [
                     "Dell Chromebook 11 5190 2-in-1"
                 ],
-                "boardname": "NASHER360"
+                "boardname": [
+                    "NASHER360"
+                ]
             },
             {
                 "device": [
                     "Lenovo Thinkpad 11e/Yoga 11e (G4)"
                 ],
-                "boardname": "PYRO"
+                "boardname": [
+                    "PYRO"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook C423",
                     "ASUS Chromebook CX1400CNA"
                 ],
-                "boardname": "RABBID"
+                "boardname": [
+                    "RABBID"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook Flip C213SA",
                     "Acer Chromebook Spin 11 (R751T)"
                 ],
-                "boardname": "REEF"
+                "boardname": [
+                    "REEF"
+                ]
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook"
                 ],
-                "boardname": "ROBO"
+                "boardname": [
+                    "ROBO"
+                ]
             },
             {
                 "device": [
                     "Lenovo 500e Chromebook"
                 ],
-                "boardname": "ROBO360"
+                "boardname": [
+                    "ROBO360"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 15 (CB515-1H, CB515-1HT)"
                 ],
-                "boardname": "SAND"
+                "boardname": [
+                    "SAND"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 11 (CB311-8H, CB311-8HT)"
                 ],
-                "boardname": "SANTA"
+                "boardname": [
+                    "SANTA"
+                ]
             },
             {
                 "device": [
@@ -544,7 +692,9 @@
                     "HP Chromebook 11 G6",
                     "HP Chromebook 14 G5"
                 ],
-                "boardname": "SNAPPY"
+                "boardname": [
+                    "SNAPPY"
+                ]
             },
             {
                 "device": [
@@ -554,7 +704,9 @@
                     "Sector 5 E3 Chromebook",
                     "Viglen Chromebook 11C"
                 ],
-                "boardname": "WHITETIP"
+                "boardname": [
+                    "WHITETIP"
+                ]
             }
         ]
     },
@@ -567,50 +719,66 @@
                 "device": [
                     "Acer Chromebook 13 (CB713-1W)"
                 ],
-                "boardname": "AKALI"
+                "boardname": [
+                    "AKALI"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 13 (CP713-1WN)"
                 ],
-                "boardname": "AKALI360"
+                "boardname": [
+                    "AKALI360"
+                ]
             },
             {
                 "device": [
                     "Google Pixelbook Go (2019)"
                 ],
-                "boardname": "ATLAS"
+                "boardname": [
+                    "ATLAS"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 715 (CB715)"
                 ],
-                "boardname": "BARD"
+                "boardname": [
+                    "BARD"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 714 (CB714)"
                 ],
-                "boardname": "EKKO"
+                "boardname": [
+                    "EKKO"
+                ]
             },
             {
                 "device": [
                     "Meet Compute System - Series One (Lenovo)"
                 ],
-                "boardname": "ENDEAVOUR",
+                "boardname": [
+                    "ENDEAVOUR"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Excelsior_wp.jpg\" class=\"internal\" title=\"Excelsior wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Google Pixelbook (2017)"
                 ],
-                "boardname": "EVE"
+                "boardname": [
+                    "EVE"
+                ]
             },
             {
                 "device": [
                     "Asus Google Meet kit (KBL)"
                 ],
-                "boardname": "EXCELSIOR",
+                "boardname": [
+                    "EXCELSIOR"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Excelsior_wp.jpg\" class=\"internal\" title=\"Excelsior wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
@@ -618,90 +786,118 @@
                     "AOpen Chromebox Commercial 2",
                     "Newline Chromebox A10"
                 ],
-                "boardname": "JAX",
+                "boardname": [
+                    "JAX"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/fizz_wp.jpg\" class=\"internal\" title=\"fizz wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Acer Chromebase 24I2"
                 ],
-                "boardname": "KARMA",
+                "boardname": [
+                    "KARMA"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, screw"
             },
             {
                 "device": [
                     "HP Chromebox G2"
                 ],
-                "boardname": "KENCH",
+                "boardname": [
+                    "KENCH"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/fizz_wp.jpg\" class=\"internal\" title=\"fizz wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Asus Chromebook C425"
                 ],
-                "boardname": "LEONA"
+                "boardname": [
+                    "LEONA"
+                ]
             },
             {
                 "device": [
                     "Samsung Chromebook Plus V2"
                 ],
-                "boardname": "NAUTILUS"
+                "boardname": [
+                    "NAUTILUS"
+                ]
             },
             {
                 "device": [
                     "Google Pixel Slate"
                 ],
-                "boardname": "NOCTURNE"
+                "boardname": [
+                    "NOCTURNE"
+                ]
             },
             {
                 "device": [
                     "Lenovo Yoga Chromebook C630"
                 ],
-                "boardname": "PANTHEON"
+                "boardname": [
+                    "PANTHEON"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook Flip C433/C434"
                 ],
-                "boardname": "SHYVANA"
+                "boardname": [
+                    "SHYVANA"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebox CXI3"
                 ],
-                "boardname": "SION",
+                "boardname": [
+                    "SION"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/fizz_wp.jpg\" class=\"internal\" title=\"fizz wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "HP Chromebook x360 14"
                 ],
-                "boardname": "SONA"
+                "boardname": [
+                    "SONA"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook X2"
                 ],
-                "boardname": "SORAKA"
+                "boardname": [
+                    "SORAKA"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 15 G1"
                 ],
-                "boardname": "SYNDRA"
+                "boardname": [
+                    "SYNDRA"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebox 3 (CN65)"
                 ],
-                "boardname": "TEEMO",
+                "boardname": [
+                    "TEEMO"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/fizz_wp.jpg\" class=\"internal\" title=\"fizz wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Dell Inspiron Chromebook 14 (7460)"
                 ],
-                "boardname": "VAYNE"
+                "boardname": [
+                    "VAYNE"
+                ]
             },
             {
                 "device": [
@@ -710,7 +906,9 @@
                     "SMART Chromebox G3",
                     "ViewSonic NMP660 Chromebox"
                 ],
-                "boardname": "WUKONG",
+                "boardname": [
+                    "WUKONG"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/fizz_wp.jpg\" class=\"internal\" title=\"fizz wp.jpg\" target=\"_blank\">screw</a>"
             }
         ]
@@ -724,101 +922,133 @@
                 "device": [
                     "Asus Chromebook Flip C214/C234"
                 ],
-                "boardname": "AMPTON"
+                "boardname": [
+                    "AMPTON"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook Flip C204"
                 ],
-                "boardname": "APEL"
+                "boardname": [
+                    "APEL"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook x360 12b-ca0"
                 ],
-                "boardname": "BLOOG"
+                "boardname": [
+                    "BLOOG"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 14a-na0"
                 ],
-                "boardname": "BLOOGLET"
+                "boardname": [
+                    "BLOOGLET"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook x360 14a-ca0/14b-ca0"
                 ],
-                "boardname": "BLOOGUARD"
+                "boardname": [
+                    "BLOOGUARD"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 315 (CB315-3H, CB315-3HT)"
                 ],
-                "boardname": "BLORB"
+                "boardname": [
+                    "BLORB"
+                ]
             },
             {
                 "device": [
                     "Samsung Chromebook 4"
                 ],
-                "boardname": "BLUEBIRD"
+                "boardname": [
+                    "BLUEBIRD"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 311",
                     "(CB311-9H, CB311-9HT, C733, C733U, C733T)"
                 ],
-                "boardname": "BOBBA"
+                "boardname": [
+                    "BOBBA"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 311 (CP311-2H, CP311-2HN)",
                     "Acer Chromebook Spin 511 (R752T, R752TN)"
                 ],
-                "boardname": "BOBBA360"
+                "boardname": [
+                    "BOBBA360"
+                ]
             },
             {
                 "device": [
                     "Samsung Chromebook 4+"
                 ],
-                "boardname": "CASTA"
+                "boardname": [
+                    "CASTA"
+                ]
             },
             {
                 "device": [
                     "NEC Chromebook Y2"
                 ],
-                "boardname": "DOOD"
+                "boardname": [
+                    "DOOD"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 14 G6"
                 ],
-                "boardname": "DORP"
+                "boardname": [
+                    "DORP"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 314 (C933, C933T, CB314-1H, CB314-1HT)",
                     "Packard Bell Chromebook 314 (PCB314)"
                 ],
-                "boardname": "DROID"
+                "boardname": [
+                    "DROID"
+                ]
             },
             {
                 "device": [
                     "Dell Chromebook 3100"
                 ],
-                "boardname": "FLEEX"
+                "boardname": [
+                    "FLEEX"
+                ]
             },
             {
                 "device": [
                     "CTL Chromebook VX11/VX11T",
                     "Poin2 Chromebook 11P"
                 ],
-                "boardname": "FOOB"
+                "boardname": [
+                    "FOOB"
+                ]
             },
             {
                 "device": [
                     "Poin2 Chromebook 11P"
                 ],
-                "boardname": "FOOB360"
+                "boardname": [
+                    "FOOB360"
+                ]
             },
             {
                 "device": [
@@ -837,7 +1067,9 @@
                     "WS Chromebook A101",
                     "Zyrex Chromebook M432"
                 ],
-                "boardname": "GARG"
+                "boardname": [
+                    "GARG"
+                ]
             },
             {
                 "device": [
@@ -855,62 +1087,82 @@
                     "WS Chromebook A101",
                     "Zyrex Chromebook 360"
                 ],
-                "boardname": "GARG360"
+                "boardname": [
+                    "GARG360"
+                ]
             },
             {
                 "device": [
                     "CTL Chromebook NL81/NL81T"
                 ],
-                "boardname": "GARFOUR"
+                "boardname": [
+                    "GARFOUR"
+                ]
             },
             {
                 "device": [
                     "Dell Chromebook 3100 2-in-1"
                 ],
-                "boardname": "GRABBITER"
+                "boardname": [
+                    "GRABBITER"
+                ]
             },
             {
                 "device": [
                     "Lenovo Chromebook S340",
                     "Lenovo IdeaPad Flex 3 Chromebook 14\""
                 ],
-                "boardname": "LASER14"
+                "boardname": [
+                    "LASER14"
+                ]
             },
             {
                 "device": [
                     "Lenovo Ideapad 3 Chromebook"
                 ],
-                "boardname": "LICK"
+                "boardname": [
+                    "LICK"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook x360 11 G2 EE"
                 ],
-                "boardname": "MEEP"
+                "boardname": [
+                    "MEEP"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 11 G7 EE"
                 ],
-                "boardname": "MIMROCK"
+                "boardname": [
+                    "MIMROCK"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook C424"
                 ],
-                "boardname": "NOSPIKE"
+                "boardname": [
+                    "NOSPIKE"
+                ]
             },
             {
                 "device": [
                     "Dell Chromebook 3400"
                 ],
-                "boardname": "ORBATRIX"
+                "boardname": [
+                    "ORBATRIX"
+                ]
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook Gen 2"
                 ],
-                "boardname": "PHASER"
+                "boardname": [
+                    "PHASER"
+                ]
             },
             {
                 "device": [
@@ -920,31 +1172,41 @@
                     "Lenovo IdeaPad Flex 3 Chromebook 11\"",
                     "NEC Chromebook Y1"
                 ],
-                "boardname": "PHASER360"
+                "boardname": [
+                    "PHASER360"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 512 (C851/C851T)"
                 ],
-                "boardname": "SPARKY"
+                "boardname": [
+                    "SPARKY"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 512 (R851TN)"
                 ],
-                "boardname": "SPARKY360"
+                "boardname": [
+                    "SPARKY360"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 11 G8 EE"
                 ],
-                "boardname": "VORTICON"
+                "boardname": [
+                    "VORTICON"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook x360 11 G3 EE"
                 ],
-                "boardname": "VORTININJA"
+                "boardname": [
+                    "VORTININJA"
+                ]
             }
         ]
     },
@@ -957,13 +1219,17 @@
                 "device": [
                     "Dell Latitude 5300 2-in-1 Chromebook Enterprise"
                 ],
-                "boardname": "ARCADA"
+                "boardname": [
+                    "ARCADA"
+                ]
             },
             {
                 "device": [
                     "Dell Latitude 5400 Chromebook Enterprise"
                 ],
-                "boardname": "SARIEN"
+                "boardname": [
+                    "SARIEN"
+                ]
             }
         ]
     },
@@ -976,21 +1242,27 @@
                 "device": [
                     "Lenovo Ideapad Flex 5 Chromebook"
                 ],
-                "boardname": "AKEMI"
+                "boardname": [
+                    "AKEMI"
+                ]
             },
             {
                 "device": [
                     "ASUS Meet Compute System (Intel 10th Gen)",
                     "CTL Meet Compute System (Intel 10th Gen)"
                 ],
-                "boardname": "AMBASSADOR",
+                "boardname": [
+                    "AMBASSADOR"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, jumper"
             },
             {
                 "device": [
                     "HP Chromebase 21.5\""
                 ],
-                "boardname": "DOOLY",
+                "boardname": [
+                    "DOOLY"
+                ],
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, jumper"
             },
@@ -998,33 +1270,43 @@
                 "device": [
                     "HP Chromebook x360 14c-ca0"
                 ],
-                "boardname": "DRAGONAIR"
+                "boardname": [
+                    "DRAGONAIR"
+                ]
             },
             {
                 "device": [
                     "Dell Latitude 7410 Chromebook Enterprise"
                 ],
-                "boardname": "DRALLION",
+                "boardname": [
+                    "DRALLION"
+                ],
                 "rwLegacy": true
             },
             {
                 "device": [
                     "Dell Latitude 7410 2-in-1 Chromebook Enterprise"
                 ],
-                "boardname": "DRALLION360",
+                "boardname": [
+                    "DRALLION360"
+                ],
                 "rwLegacy": true
             },
             {
                 "device": [
                     "HP Pro c640 Chromebook"
                 ],
-                "boardname": "DRATINI"
+                "boardname": [
+                    "DRATINI"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebox 4"
                 ],
-                "boardname": "DUFFY",
+                "boardname": [
+                    "DUFFY"
+                ],
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Duffy_wp_jumper.png\" class=\"internal\" title=\"Duffy wp jumper.png\" target=\"_blank\">jumper</a>"
             },
@@ -1032,7 +1314,9 @@
                 "device": [
                     "Asus Fanless Chromebox"
                 ],
-                "boardname": "FAFFY",
+                "boardname": [
+                    "FAFFY"
+                ],
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, jumper"
             },
@@ -1040,27 +1324,35 @@
                 "device": [
                     "Meet Compute System - Series One (Intel 10th Gen)"
                 ],
-                "boardname": "GENESIS",
+                "boardname": [
+                    "GENESIS"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, jumper"
             },
             {
                 "device": [
                     "Asus Chromebook Flip C436FA"
                 ],
-                "boardname": "HELIOS"
+                "boardname": [
+                    "HELIOS"
+                ]
             },
             {
                 "device": [
                     "HP Elite c1030 Chromebook",
                     "HP Chromebook x360 13c-ca0"
                 ],
-                "boardname": "JINLON"
+                "boardname": [
+                    "JINLON"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebox CXI4"
                 ],
-                "boardname": "KAISA",
+                "boardname": [
+                    "KAISA"
+                ],
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Kaisa_wp.jpg\" class=\"internal\" title=\"Kaisa_wp.jpg\" target=\"_blank\">jumper</a>"
             },
@@ -1068,31 +1360,41 @@
                 "device": [
                     "Acer Chromebook 712 (C871)"
                 ],
-                "boardname": "KINDRED"
+                "boardname": [
+                    "KINDRED"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 713 (CP713-2W)"
                 ],
-                "boardname": "KLED"
+                "boardname": [
+                    "KLED"
+                ]
             },
             {
                 "device": [
                     "Samsung Galaxy Chromebook"
                 ],
-                "boardname": "KOHAKU"
+                "boardname": [
+                    "KOHAKU"
+                ]
             },
             {
                 "device": [
                     "Samsung Galaxy Chromebook 2"
                 ],
-                "boardname": "NIGHTFURY"
+                "boardname": [
+                    "NIGHTFURY"
+                ]
             },
             {
                 "device": [
                     "HP Chromebox G3"
                 ],
-                "boardname": "NOIBAT",
+                "boardname": [
+                    "NOIBAT"
+                ],
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Noibat_wp.png\" class=\"internal\" title=\"Noibat wp.png\" target=\"_blank\">jumper</a>"
             },
@@ -1102,7 +1404,9 @@
                     "Promethean Chromebox 2",
                     "ViewSonic NMP760 Chromebox"
                 ],
-                "boardname": "WYVERN",
+                "boardname": [
+                    "WYVERN"
+                ],
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Wyvern_WP_jumper.png\" class=\"internal\" title=\"Wyvern WP jumper.png\" target=\"_blank\">jumper</a>"
             }
@@ -1117,81 +1421,107 @@
                 "device": [
                     "FMV Chromebook 14F"
                 ],
-                "boardname": "CHRONICLER"
+                "boardname": [
+                    "CHRONICLER"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook Flip CX3"
                 ],
-                "boardname": "COLLIS"
+                "boardname": [
+                    "COLLIS"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook Flip CX5 (CX5400)"
                 ],
-                "boardname": "COPANO"
+                "boardname": [
+                    "COPANO"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook Flip CX55, CX5 (CX5500), C536"
                 ],
-                "boardname": "DELBIN"
+                "boardname": [
+                    "DELBIN"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook CX9 (CX9400)"
                 ],
-                "boardname": "DROBIT"
+                "boardname": [
+                    "DROBIT"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook x360 14c-cc0"
                 ],
-                "boardname": "ELDRID"
+                "boardname": [
+                    "ELDRID"
+                ]
             },
             {
                 "device": [
                     "HP Pro c640 G2 Chromebook",
                     "HP Chromebook 14b-nb0"
                 ],
-                "boardname": "ELEMI"
+                "boardname": [
+                    "ELEMI"
+                ]
             },
             {
                 "device": [
                     "Lenovo IdeaPad Flex 5i Chromebook"
                 ],
-                "boardname": "LILLIPUP"
+                "boardname": [
+                    "LILLIPUP"
+                ]
             },
             {
                 "device": [
                     "Lenovo 5i-14 Chromebook",
                     "Lenovo Slim 5 Chromebook"
                 ],
-                "boardname": "LINDAR"
+                "boardname": [
+                    "LINDAR"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 514 (CP514-2H)"
                 ],
-                "boardname": "VOEMA"
+                "boardname": [
+                    "VOEMA"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 515 (CB515-1W, CB515-1WT)"
                 ],
-                "boardname": "VOLET"
+                "boardname": [
+                    "VOLET"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 514 (CB514-1W, CB514-1WT)"
                 ],
-                "boardname": "VOLTA"
+                "boardname": [
+                    "VOLTA"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 713 (CP713-3W)"
                 ],
-                "boardname": "VOXEL"
+                "boardname": [
+                    "VOXEL"
+                ]
             }
         ]
     },
@@ -1206,142 +1536,186 @@
                     "Multilaser Chromebook M11C-PC919",
                     "Allied Chromebook 11 N5100E"
                 ],
-                "boardname": "BEADRIX"
+                "boardname": [
+                    "BEADRIX"
+                ]
             },
             {
                 "device": [
                     "Lenovo Flex 3i 15 / Ideapad Flex 3i Chromebook"
                 ],
-                "boardname": "BEETLEY"
+                "boardname": [
+                    "BEETLEY"
+                ]
             },
             {
                 "device": [
                     "Lenovo 3i-15 Chromebook"
                 ],
-                "boardname": "BLIPPER"
+                "boardname": [
+                    "BLIPPER"
+                ]
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook Gen 3"
                 ],
-                "boardname": "BOOKEM",
+                "boardname": [
+                    "BOOKEM"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Boten_wp.jpg\" class=\"internal\" title=\"Boten wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Lenovo 500e Chromebook Gen 3"
                 ],
-                "boardname": "BOTEN",
+                "boardname": [
+                    "BOTEN"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Boten_wp.jpg\" class=\"internal\" title=\"Boten wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Lenovo Flex 3i-11 / IdeaPad Flex 3i Chromebook"
                 ],
-                "boardname": "BOTENFLEX",
+                "boardname": [
+                    "BOTENFLEX"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Boten_wp.jpg\" class=\"internal\" title=\"Boten wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Samsung Galaxy Chromebook 2 360"
                 ],
-                "boardname": "BUGZZY"
+                "boardname": [
+                    "BUGZZY"
+                ]
             },
             {
                 "device": [
                     "Dell Chromebook 3110"
                 ],
-                "boardname": "CRET",
+                "boardname": [
+                    "CRET"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Cret_jumper.jpg\" class=\"internal\" title=\"Cret_jumper.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Dell Chromebook 3110 2-in-1"
                 ],
-                "boardname": "CRET360"
+                "boardname": [
+                    "CRET360"
+                ]
             },
             {
                 "device": [
                     "AOPEN Chromebox Mini 2"
                 ],
-                "boardname": "DEXI"
+                "boardname": [
+                    "DEXI"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebox Mini CXM1"
                 ],
-                "boardname": "DITA"
+                "boardname": [
+                    "DITA"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook x360 11 G4 EE",
                     "HP Fortis x360 11 G3 J Chromebook"
                 ],
-                "boardname": "DRAWCIA",
+                "boardname": [
+                    "DRAWCIA"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Drawcia_wp.jpg\" class=\"internal\" title=\"Drawcia wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "HP Chromebook 11 G9 EE"
                 ],
-                "boardname": "DRAWLAT",
+                "boardname": [
+                    "DRAWLAT"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Drawlat_wp.jpg\" class=\"internal\" title=\"Drawlat wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "HP Chromebook 14 G7"
                 ],
-                "boardname": "DRAWMAN",
+                "boardname": [
+                    "DRAWMAN"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Drawman_wp.jpg\" class=\"internal\" title=\"Drawman wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "HP Fortis 14 G10 Chromebook"
                 ],
-                "boardname": "DRAWPER",
+                "boardname": [
+                    "DRAWPER"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Drawman_wp.jpg\" class=\"internal\" title=\"Drawman wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Asus Chromebook CX1500CKA"
                 ],
-                "boardname": "GALITH"
+                "boardname": [
+                    "GALITH"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook CX1500FKA"
                 ],
-                "boardname": "GALITH360"
+                "boardname": [
+                    "GALITH360"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook CX1700CKA"
                 ],
-                "boardname": "GALLOP"
+                "boardname": [
+                    "GALLOP"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook CX1 CX1102"
                 ],
-                "boardname": "GALNAT"
+                "boardname": [
+                    "GALNAT"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook Flip CX1 CX1102"
                 ],
-                "boardname": "GALNAT360"
+                "boardname": [
+                    "GALNAT360"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook CX1"
                 ],
-                "boardname": "GALTIC"
+                "boardname": [
+                    "GALTIC"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook CX1400FKA"
                 ],
-                "boardname": "GALTIC360"
+                "boardname": [
+                    "GALTIC360"
+                ]
             },
             {
                 "device": [
@@ -1352,7 +1726,9 @@
                     "Poin2 Chromebook 11B",
                     "Zyrex Chromebook M432-64"
                 ],
-                "boardname": "KRACKO"
+                "boardname": [
+                    "KRACKO"
+                ]
             },
             {
                 "device": [
@@ -1360,58 +1736,76 @@
                     "LG Chromebook 11TC50Q/11TQ50Q",
                     "Poin2 Chromebook 11E"
                 ],
-                "boardname": "KRACKO360"
+                "boardname": [
+                    "KRACKO360"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook x360 14a-ca1"
                 ],
-                "boardname": "LANDIA"
+                "boardname": [
+                    "LANDIA"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 15a-na0"
                 ],
-                "boardname": "LANDRID",
+                "boardname": [
+                    "LANDRID"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Landrid_wp.jpg\" class=\"internal\" title=\"Landrid wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "HP Chromebook 14a-na1"
                 ],
-                "boardname": "LANTIS",
+                "boardname": [
+                    "LANTIS"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Lantis_wp.jpg\" class=\"internal\" title=\"Lantis wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "HP Chromebook x360 14b-cb0"
                 ],
-                "boardname": "MADOO"
+                "boardname": [
+                    "MADOO"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 314 [CP314-1H, CP314-1HN]"
                 ],
-                "boardname": "MAGISTER"
+                "boardname": [
+                    "MAGISTER"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 512 [C852]"
                 ],
-                "boardname": "MAGLET"
+                "boardname": [
+                    "MAGLET"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 512 [R853TA/R853TNA]"
                 ],
-                "boardname": "MAGLIA",
+                "boardname": [
+                    "MAGLIA"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Maglia_wp.jpg\" class=\"internal\" title=\"Maglia wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Acer Chromebook 511 [C733/C734]"
                 ],
-                "boardname": "MAGLITH",
+                "boardname": [
+                    "MAGLITH"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Maglith_wp.jpg\" class=\"internal\" title=\"Maglith wp.jpg\" target=\"_blank\">jumper</a>"
             
             },
@@ -1419,7 +1813,9 @@
                 "device": [
                     "Acer Chromebook 315 [CB315-4H/4HT]"
                 ],
-                "boardname": "MAGMA",
+                "boardname": [
+                    "MAGMA"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/magma_wp_jumper.jpg\" class=\"internal\" title=\"magma_wp_jumper\" target=\"_blank\">jumper</a>"
             },
             {
@@ -1427,33 +1823,43 @@
                     "Acer Chromebook 314 [CB314-3H/3HT, C934/C934T]",
                     "Packard Bell Chromebook 314"
                 ],
-                "boardname": "MAGNETO"
+                "boardname": [
+                    "MAGNETO"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 511 [R753T]"
                 ],
-                "boardname": "MAGOLOR"
+                "boardname": [
+                    "MAGOLOR"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 317 [CB317-1H]"
                 ],
-                "boardname": "MAGPIE",
+                "boardname": [
+                    "MAGPIE"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Magpie_wp_jumper.png\" class=\"internal\" title=\"Magpie wp jumper.png\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "NEC Chromebook Y3"
                 ],
-                "boardname": "METAKNIGHT",
+                "boardname": [
+                    "METAKNIGHT"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Magpie_wp_jumper.png\" class=\"internal\" title=\"Magpie wp jumper.png\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Gateway Chromebook 15"
                 ],
-                "boardname": "PASARA"
+                "boardname": [
+                    "PASARA"
+                ]
             },
             {
                 "device": [
@@ -1463,7 +1869,9 @@
                     "Edxis E-Lite Chromebook 11",
                     "Multilaser Chromebook M11C-PC924"
                 ],
-                "boardname": "PEEZER"
+                "boardname": [
+                    "PEEZER"
+                ]
             },
             {
                 "device": [
@@ -1472,7 +1880,9 @@
                     "SPC Chromebook Z1 Mini",
                     "Zyrex Chromebook M432-2"
                 ],
-                "boardname": "PIRETTE"
+                "boardname": [
+                    "PIRETTE"
+                ]
             },
             {
                 "device": [
@@ -1480,39 +1890,51 @@
                     "CTL Chromebook Enterprise",
                     "Gateway Chromebook 14"
                 ],
-                "boardname": "PIRIKA"
+                "boardname": [
+                    "PIRIKA"
+                ]
             },
             {
                 "device": [
                     "Samsung Galaxy Chromebook Go"
                 ],
-                "boardname": "SASUKE"
+                "boardname": [
+                    "SASUKE"
+                ]
             },
             {
                 "device": [
                     "SamsungGalaxy Chromebook Go 11"
                 ],
-                "boardname": "SASUKETTE"
+                "boardname": [
+                    "SASUKETTE"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook CR1100CKA"
                 ],
-                "boardname": "STORO",
+                "boardname": [
+                    "STORO"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/storo_wp_jumper.jpg\" class=\"internal\" title=\"storo_wp_jumper\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Asus Chromebook Flip CR1100FKA"
                 ],
-                "boardname": "STORO360",
+                "boardname": [
+                    "STORO360"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/storo_wp_jumper.jpg\" class=\"internal\" title=\"storo_wp_jumper\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "ASUS Fanless Chromebox CF40"
                 ],
-                "boardname": "TARANZA"
+                "boardname": [
+                    "TARANZA"
+                ]
             }
         ]
     },
@@ -1525,111 +1947,147 @@
                 "device": [
                     "HP Elite c640 14 inch G3 Chromebook"
                 ],
-                "boardname": "ANAHERA"
+                "boardname": [
+                    "ANAHERA"
+                ]
             },
             {
                 "device": [
                     "AOpen Chromebox Commercial 3"
                 ],
-                "boardname": "AURASH"
+                "boardname": [
+                    "AURASH"
+                ]
             },
             {
                 "device": [
                     "Framework Laptop Chromebook Edition"
                 ],
-                "boardname": "BANSHEE"
+                "boardname": [
+                    "BANSHEE"
+                ]
             },
             {
                 "device": [
                     "Dell Latitude 5430 Chromebook"
                 ],
-                "boardname": "CROTA"
+                "boardname": [
+                    "CROTA"
+                ]
             },
             {
                 "device": [
                     "Dell Latitude 5430 2-in-1 Chromebook"
                 ],
-                "boardname": "CROTA360"
+                "boardname": [
+                    "CROTA360"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Plus Spin 514 [CP514-4HN]"
                 ],
-                "boardname": "DOCHI"
+                "boardname": [
+                    "DOCHI"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook Flip CX5 (CX5601)"
                 ],
-                "boardname": "FELWINTER"
+                "boardname": [
+                    "FELWINTER"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook x360 14c-cd0"
                 ],
-                "boardname": "GIMBLE"
+                "boardname": [
+                    "GIMBLE"
+                ]
             },
             {
                 "device": [
                     "HP Chromebox Enterprise G4"
                 ],
-                "boardname": "GLADIOS"
+                "boardname": [
+                    "GLADIOS"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 714 [CP714-1WN/2WN]"
                 ],
-                "boardname": "KANO"
+                "boardname": [
+                    "KANO"
+                ]
             },
             {
                 "device": [
                     "Lenovo ThinkCentre M60q Chromebox"
                 ],
-                "boardname": "KINOX"
+                "boardname": [
+                    "KINOX"
+                ]
             },
             {
                 "device": [
                     "ASUS Chromebox 5 (CN67)"
                 ],
-                "boardname": "KULDAX"
+                "boardname": [
+                    "KULDAX"
+                ]
             },
             {
                 "device": [
                     "CTL Chromebox CBx3"
                 ],
-                "boardname": "LISBON"
+                "boardname": [
+                    "LISBON"
+                ]
             },
             {
                 "device": [
                     "ASUS Chromebook Plus CX34"
                 ],
-                "boardname": "MARASOV"
+                "boardname": [
+                    "MARASOV"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook CX34 Flip",
                     "Asus Chromebook Vibe CX34 Flip"
                 ],
-                "boardname": "MITHRAX"
+                "boardname": [
+                    "MITHRAX"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebox CXI5"
                 ],
-                "boardname": "MOLI"
+                "boardname": [
+                    "MOLI"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Plus 515 (CB515-2H, CB515-2HT)"
                 ],
-                "boardname": "OMNIGUL",
+                "boardname": [
+                    "OMNIGUL"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
             },
             {
                 "device": [
                     "Acer Chromebook Plus Enterprise 515 (CBE595-2/CBE595-2T)"
                 ],
-                "boardname": "ONMIKNIGHT",
+                "boardname": [
+                    "ONMIKNIGHT"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
             },
             {
@@ -1637,56 +2095,74 @@
                     "Acer Chromebook 516 GE [CBG516-1H]",
                     "Acer Chromebook Plus 516 GE [CBG516-2H]"
                 ],
-                "boardname": "OSIRIS",
+                "boardname": [
+                    "OSIRIS"
+                ],
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
             },
             {
                 "device": [
                     "Lenovo ThinkPad C14 Gen 1 Chromebook"
                 ],
-                "boardname": "PRIMUS"
+                "boardname": [
+                    "PRIMUS"
+                ]
             },
             {
                 "device": [
                     "HP Elite Dragonfly Chromebook"
                 ],
-                "boardname": "REDRIX"
+                "boardname": [
+                    "REDRIX"
+                ]
             },
             {
                 "device": [
                     "Lenovo Flex 5i Chromebook / IdeaPad Flex 5i Chromebook"
                 ],
-                "boardname": "TAEKO"
+                "boardname": [
+                    "TAEKO"
+                ]
             },
             {
                 "device": [
                     "Lenovo IdeaPad Gaming Chromebook 16"
                 ],
-                "boardname": "TANIKS"
+                "boardname": [
+                    "TANIKS"
+                ]
             },
             {
                 "device": [
                     "Lenovo 5i Chromebook 16\""
                 ],
-                "boardname": "TARLO"
+                "boardname": [
+                    "TARLO"
+                ]
             },
             {
                 "device": [
                     "HP Dragonfly Pro Chromebook"
                 ],
-                "boardname": "VELL"
+                "boardname": [
+                    "VELL"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Vero 514 (CBV514-1H, CBV514-1HT)"
                 ],
-                "boardname": "VOLMAR"
+                "boardname": [
+                    "VOLMAR"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Vero 712 (CV872, CV872T)"
                 ],
-                "boardname": "ZAVALA"
+                "boardname": [
+                    "ZAVALA"
+                ]
             }
         ]
     },
@@ -1699,43 +2175,57 @@
                 "device": [
                     "ASUS Chromebook CR12"
                 ],
-                "boardname": "ANRAGGAR"
+                "boardname": [
+                    "ANRAGGAR"
+                ]
             },
             {
                 "device": [
                     "ASUS Chromebook CR12 Flip"
                 ],
-                "boardname": "ANRAGGAR360"
+                "boardname": [
+                    "ANRAGGAR360"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 512 (R856T, R856LT)"
                 ],
-                "boardname": "CRAASK"
+                "boardname": [
+                    "CRAASK"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 311"
                 ],
-                "boardname": "CRAASKANA"
+                "boardname": [
+                    "CRAASKANA"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 511 (R756T, R756LT)"
                 ],
-                "boardname": "CRAASKBOWL"
+                "boardname": [
+                    "CRAASKBOWL"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 315 (CB315-5H, CB315-5HT)"
                 ],
-                "boardname": "CRAASKINO"
+                "boardname": [
+                    "CRAASKINO"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 511 (C736, C736T, C736L, C736LT)"
                 ],
-                "boardname": "CRAASKVIN"
+                "boardname": [
+                    "CRAASKVIN"
+                ]
             },
             {
                 "device": [
@@ -1743,110 +2233,146 @@
                     "Acer Chromebook 314 (CB314-4H, CB314-4HT)",
                     "Acer Chromebook Plus 514 (CB514-4H, CB514-4HT)"
                 ],
-                "boardname": "CRAASNETO"
+                "boardname": [
+                    "CRAASNETO"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 314 (CP314-2H, CP314-2HN)"
                 ],
-                "boardname": "CRAASWELL"
+                "boardname": [
+                    "CRAASWELL"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook Plus x360"
                 ],
-                "boardname": "JOXER"
+                "boardname": [
+                    "JOXER"
+                ]
             },
             {
                 "device": [
                     "Lenovo 500e Yoga Chromebook Gen 4",
                     "Lenovo Flex 3i Chromebook 12\" / IdeaPad Flex 3i Chromebook 12\""
                 ],
-                "boardname": "PUJJO"
+                "boardname": [
+                    "PUJJO"
+                ]
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook Gen 4"
                 ],
-                "boardname": "PUJJO1E"
+                "boardname": [
+                    "PUJJO1E"
+                ]
             },
             {
                 "device": [
                     "Lenovo 14e Chromebook Gen 3"
                 ],
-                "boardname": "PUJJOTEEN"
+                "boardname": [
+                    "PUJJOTEEN"
+                ]
             },
             {
                 "device": [
                     "Lenovo Ideapad Slim 3i Chromebook"
                 ],
-                "boardname": "PUJJOTEEN15W"
+                "boardname": [
+                    "PUJJOTEEN15W"
+                ]
             },
             {
                 "device": [
                     "CTL Chromebook NL73"
                 ],
-                "boardname": "QUANDISO"
+                "boardname": [
+                    "QUANDISO"
+                ]
             },
             {
                 "device": [
                     "CTL Chromebook NL73T"
                 ],
-                "boardname": "QUANDISO360"
+                "boardname": [
+                    "QUANDISO360"
+                ]
             },
             {
                 "device": [
                     "Dell Chromebook 3120"
                 ],
-                "boardname": "ULDREN"
+                "boardname": [
+                    "ULDREN"
+                ]
             },
             {
                 "device": [
                     "Dell Chromebook 3120 2-in-1"
                 ],
-                "boardname": "ULDREN360"
+                "boardname": [
+                    "ULDREN360"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook CR11 [CR1102C]"
                 ],
-                "boardname": "XIVU"
+                "boardname": [
+                    "XIVU"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook CR11 [CR1102F]"
                 ],
-                "boardname": "XIVU360"
+                "boardname": [
+                    "XIVU360"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook Plus 14a"
                 ],
-                "boardname": "YAHIKO"
+                "boardname": [
+                    "YAHIKO"
+                ]
             },
             {
                 "device": [
                     "HP Fortis 14 inch G11 Chromebook"
                 ],
-                "boardname": "YAVIJO"
+                "boardname": [
+                    "YAVIJO"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 15a-nb0"
                 ],
-                "boardname": "YAVIKS"
+                "boardname": [
+                    "YAVIKS"
+                ]
             },
             {
                 "device": [
                     "HP Fortis 11 inch G10 Chromebook"
                 ],
-                "boardname": "YAVILLA"
+                "boardname": [
+                    "YAVILLA"
+                ]
             },
             {
                 "device": [
                     "HP Fortis x360 11 inch G5 Chromebook"
                 ],
-                "boardname": "YAVILLY"
+                "boardname": [
+                    "YAVILLY"
+                ]
             }
         ]
     },
@@ -1859,50 +2385,66 @@
                 "device": [
                     "Acer Chromebook 315 (CB315-2H)"
                 ],
-                "boardname": "ALEENA"
+                "boardname": [
+                    "ALEENA"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 11A G6 EE",
                     "HP Chromebook 11A G8 EE"
                 ],
-                "boardname": "BARLA"
+                "boardname": [
+                    "BARLA"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 14A G5"
                 ],
-                "boardname": "CAREENA"
+                "boardname": [
+                    "CAREENA"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook 311 (C721)"
                 ],
-                "boardname": "KASUMI"
+                "boardname": [
+                    "KASUMI"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 311 (R721T)"
                 ],
-                "boardname": "KASUMI360"
+                "boardname": [
+                    "KASUMI360"
+                ]
             },
             {
                 "device": [
                     "Lenovo 14e Chromebook (S345)"
                 ],
-                "boardname": "LIARA"
+                "boardname": [
+                    "LIARA"
+                ]
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook Gen 2 AMD"
                 ],
-                "boardname": "TREEYA"
+                "boardname": [
+                    "TREEYA"
+                ]
             },
             {
                 "device": [
                     "Lenovo 300e Chromebook Gen 2 AMD"
                 ],
-                "boardname": "TREEYA360"
+                "boardname": [
+                    "TREEYA360"
+                ]
             }
         ]
     },
@@ -1916,62 +2458,82 @@
                     "HP Pro c645 Chromebook Enterprise",
                     "HP Chromebook 14b-na0"
                 ],
-                "boardname": "BERKNIP"
+                "boardname": [
+                    "BERKNIP"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook 14a-nd0"
                 ],
-                "boardname": "DIRINBOZ"
+                "boardname": [
+                    "DIRINBOZ"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Spin 514 (CP514-1H, CP514-1W)"
                 ],
-                "boardname": "EZKINIL"
+                "boardname": [
+                    "EZKINIL"
+                ]
             },
             {
                 "device": [
                     "HP Chromebook x360 14a-cb0"
                 ],
-                "boardname": "GUMBOZ"
+                "boardname": [
+                    "GUMBOZ"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook Flip CM1"
                 ],
-                "boardname": "JELBOZ360"
+                "boardname": [
+                    "JELBOZ360"
+                ]
             },
             {
                 "device": [
                     "Lenovo ThinkPad C13 Yoga Chromebook"
                 ],
-                "boardname": "MORPHIUS"
+                "boardname": [
+                    "MORPHIUS"
+                ]
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook Gen 3"
                 ],
-                "boardname": "VILBOZ"
+                "boardname": [
+                    "VILBOZ"
+                ]
             },
             {
                 "device": [
                     "Lenovo 14e Chromebook Gen 2"
                 ],
-                "boardname": "VILBOZ14"
+                "boardname": [
+                    "VILBOZ14"
+                ]
             },
             {
                 "device": [
                     "Lenovo 300e Chromebook Gen 3",
                     "NEC Chromebook Y1 Gen3A"
                 ],
-                "boardname": "VILBOZ360"
+                "boardname": [
+                    "VILBOZ360"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook Flip CM5"
                 ],
-                "boardname": "WOOMAX"
+                "boardname": [
+                    "WOOMAX"
+                ]
             }
         ]
     },
@@ -1984,13 +2546,17 @@
                 "device": [
                     "Acer Chromebook Spin 514 [CP514-3H, CP514-3HH, CP514-3WH]"
                 ],
-                "boardname": "DEWATT"
+                "boardname": [
+                    "DEWATT"
+                ]
             },
             {
                 "device": [
                     "HP Elite c645 G2 Chromebook"
                 ],
-                "boardname": "NIPPERKIN"
+                "boardname": [
+                    "NIPPERKIN"
+                ]
             }
         ]
     },
@@ -2003,25 +2569,33 @@
                 "device": [
                     "TBD"
                 ],
-                "boardname": "CRYSTALDRIFT"
+                "boardname": [
+                    "CRYSTALDRIFT"
+                ]
             },
             {
                 "device": [
                     "Asus Chromebook CM34 Flip"
                 ],
-                "boardname": "FROSTFLOW"
+                "boardname": [
+                    "FROSTFLOW"
+                ]
             },
             {
                 "device": [
                     "Acer Chromebook Plus 514 (CB514-3H, CB514-3HT)"
                 ],
-                "boardname": "MARKARTH"
+                "boardname": [
+                    "MARKARTH"
+                ]
             },
             {
                 "device": [
                     "Dell Latitude 3445 Chromebook"
                 ],
-                "boardname": "WHITERUN"
+                "boardname": [
+                    "WHITERUN"
+                ]
             }
         ]
     }

--- a/supported-devices/devices.json
+++ b/supported-devices/devices.json
@@ -7,18 +7,14 @@
                 "device": [
                     "HP Pavilion Chromebook 14"
                 ],
-                "boardname": [
-                    "BUTTERFLY"
-                ],
+                "boardname": "BUTTERFLY",
                 "wpMethod": "<a href=\"/images/wp/Butterfly_wp_switch.jpg\" class=\"internal\" title=\"Butterfly_wp_switch.jpg\" target=\"_blank\">switch</a>"
             },
             {
                 "device": [
                     "Google Chromebook Pixel (2013)"
                 ],
-                "boardname": [
-                    "LINK"
-                ],
+                "boardname": "LINK",
                 "rwLegacy": null,
                 "wpMethod": "<a href=\"/images/wp/Link_wp_screw.jpg\" class=\"internal\" title=\"Link_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
@@ -26,36 +22,28 @@
                 "device": [
                     "Samsung Chromebook Series 5 550"
                 ],
-                "boardname": [
-                    "LUMPY"
-                ],
+                "boardname": "LUMPY",
                 "wpMethod": "<a href=\"/images/wp/Lumpy_wp_jumper.jpg\" class=\"internal\" title=\"Lumpy_wp_jumper.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Acer C7/C710 Chromebook"
                 ],
-                "boardname": [
-                    "PARROT"
-                ],
+                "boardname": "PARROT",
                 "wpMethod": "<a href=\"/images/wp/Parrot_wp_jumper.jpg\" class=\"internal\" title=\"Parrot_wp_jumper.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Lenovo Thinkpad X131e Chromebook"
                 ],
-                "boardname": [
-                    "STOUT"
-                ],
+                "boardname": "STOUT",
                 "wpMethod": "<a href=\"/images/wp/stout_wp.jpg\" class=\"internal\" title=\"stout wp.jpg\" target=\"_blank\">switch</a>"
             },
             {
                 "device": [
                     "Samsung Chromebox Series 3"
                 ],
-                "boardname": [
-                    "STUMPY"
-                ],
+                "boardname": "STUMPY",
                 "wpMethod": "screw"
             }
         ]
@@ -69,81 +57,63 @@
                 "device": [
                     "HP Chromebook 14"
                 ],
-                "boardname": [
-                    "FALCO"
-                ],
+                "boardname": "FALCO",
                 "wpMethod": "screw"
             },
             {
                 "device": [
                     "Toshiba Chromebook 13 (CB30)"
                 ],
-                "boardname": [
-                    "LEON"
-                ],
+                "boardname": "LEON",
                 "wpMethod": "<a href=\"/images/wp/Leon_wp_screw.jpg\" class=\"internal\" title=\"Leon_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Acer Chromebox CXI"
                 ],
-                "boardname": [
-                    "MCCLOUD"
-                ],
+                "boardname": "MCCLOUD",
                 "wpMethod": "<a href=\"/images/wp/mccloud_wp.jpg\" class=\"internal\" title=\"mccloud_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "LG Chromebase 22"
                 ],
-                "boardname": [
-                    "MONROE"
-                ],
+                "boardname": "MONROE",
                 "wpMethod": "screw"
             },
             {
                 "device": [
                     "Asus Chromebox CN60"
                 ],
-                "boardname": [
-                    "PANTHER"
-                ],
+                "boardname": "PANTHER",
                 "wpMethod": "<a href=\"/images/wp/panther_wp.jpg\" class=\"internal\" title=\"panther_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Acer C720/C720P Chromebook"
                 ],
-                "boardname": [
-                    "PEPPY"
-                ],
+                "boardname": "PEPPY",
                 "wpMethod": "<a href=\"/images/wp/Peppy_wp_screw.jpg\" class=\"internal\" title=\"Peppy_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Dell Chromebox 3010"
                 ],
-                "boardname": [
-                    "TRICKY"
-                ],
+                "boardname": "TRICKY",
                 "wpMethod": "<a href=\"/images/wp/panther_wp.jpg\" class=\"internal\" title=\"panther_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Dell Chromebook 11 (CB1C13)"
                 ],
-                "boardname": [
-                    "WOLF"
-                ],
+                "boardname": "WOLF",
                 "wpMethod": "<a href=\"/images/wp/Wolf_wp_screw.jpg\" class=\"internal\" title=\"Wolf_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "HP Chromebox CB1 / G1"
                 ],
-                "boardname": [
-                    "ZAKO"
-                ],
+                "boardname": "ZAKO",
                 "wpMethod": "<a href=\"/images/wp/panther_wp.jpg\" class=\"internal\" title=\"panther_wp.jpg\" target=\"_blank\">screw</a>"
             }
         ]
@@ -157,80 +127,60 @@
                 "device": [
                     "Acer C740 Chromebook"
                 ],
-                "boardname": [
-                    "AURON_PAINE",
-                    "PAINE"
-                ]
+                "boardname": "AURON_PAINE / PAINE"
             },
             {
                 "device": [
                     "Acer C910 Chromebook (CB5-571)"
                 ],
-                "boardname": [
-                    "AURON_YUNA",
-                    "YUNA"
-                ]
+                "boardname": "AURON_YUNA / YUNA"
             },
             {
                 "device": [
                     "Acer Chromebase 24"
                 ],
-                "boardname": [
-                    "BUDDY"
-                ],
+                "boardname": "BUDDY",
                 "wpMethod": "<a href=\"/images/wp/Buddy_wp_screw.jpg\" class=\"internal\" title=\"Buddy_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Toshiba Chromebook 2 (2015)"
                 ],
-                "boardname": [
-                    "GANDOF"
-                ],
+                "boardname": "GANDOF",
                 "wpMethod": "screw"
             },
             {
                 "device": [
                     "Asus Chromebox 2 (CN62)"
                 ],
-                "boardname": [
-                    "GUADO"
-                ],
+                "boardname": "GUADO",
                 "wpMethod": "<a href=\"/images/wp/panther_wp.jpg\" class=\"internal\" title=\"panther_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Dell Chromebook 13 7310"
                 ],
-                "boardname": [
-                    "LULU"
-                ]
+                "boardname": "LULU"
             },
             {
                 "device": [
                     "Acer Chromebox CXI2"
                 ],
-                "boardname": [
-                    "RIKKU"
-                ],
+                "boardname": "RIKKU",
                 "wpMethod": "<a href=\"/images/wp/mccloud_wp.jpg\" class=\"internal\" title=\"mccloud_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Google Chromebook Pixel (2015)"
                 ],
-                "boardname": [
-                    "SAMUS"
-                ],
+                "boardname": "SAMUS",
                 "wpMethod": "<a href=\"/images/wp/Samus_wp_screw.jpg\" class=\"internal\" title=\"Samus_wp_screw.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Lenovo ThinkCentre Chromebox"
                 ],
-                "boardname": [
-                    "TIDUS"
-                ],
+                "boardname": "TIDUS",
                 "wpMethod": "<a href=\"/images/wp/tidus_wp.jpg\" class=\"internal\" title=\"tidus_wp.jpg\" target=\"_blank\">screw</a>"
             }
         ]
@@ -244,124 +194,94 @@
                 "device": [
                     "Acer Chromebook 15 (CB3-531)"
                 ],
-                "boardname": [
-                    "BANJO"
-                ]
+                "boardname": "BANJO"
             },
             {
                 "device": [
                     "Dell Chromebook 11 (3120)"
                 ],
-                "boardname": [
-                    "CANDY"
-                ]
+                "boardname": "CANDY"
             },
             {
                 "device": [
                     "Lenovo N20/N20P Chromebook"
                 ],
-                "boardname": [
-                    "CLAPPER"
-                ]
+                "boardname": "CLAPPER"
             },
             {
                 "device": [
                     "CTL N6 Education Chromebook",
                     "Lenovo N21 Chromebook"
                 ],
-                "boardname": [
-                    "ENGUARDE"
-                ]
+                "boardname": "ENGUARDE"
             },
             {
                 "device": [
                     "Lenovo ThinkPad 11e/Yoga Chromebook"
                 ],
-                "boardname": [
-                    "GLIMMER"
-                ]
+                "boardname": "GLIMMER"
             },
             {
                 "device": [
                     "Acer Chromebook 11 (CB3-111/131, C730, C730E, C735)"
                 ],
-                "boardname": [
-                    "GNAWTY"
-                ],
+                "boardname": "GNAWTY",
                 "wpMethod": "<a href=\"/images/wp/gnawty_wp.jpg\" class=\"internal\" title=\"gnawty_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Haier Chromebook G2"
                 ],
-                "boardname": [
-                    "HELI"
-                ]
+                "boardname": "HELI"
             },
             {
                 "device": [
                     "HP Chromebook 11 G3/G4",
                     "HP Chromebook 14 G4"
                 ],
-                "boardname": [
-                    "KIP"
-                ]
+                "boardname": "KIP"
             },
             {
                 "device": [
                     "AOpen Chromebox Commercial"
                 ],
-                "boardname": [
-                    "NINJA"
-                ]
+                "boardname": "NINJA"
             },
             {
                 "device": [
                     "Lenovo Ideapad 100S Chromebook"
                 ],
-                "boardname": [
-                    "ORCO"
-                ]
+                "boardname": "ORCO"
             },
             {
                 "device": [
                     "Asus Chromebook C300"
                 ],
-                "boardname": [
-                    "QUAWKS"
-                ]
+                "boardname": "QUAWKS"
             },
             {
                 "device": [
                     "Asus Chromebook C200"
                 ],
-                "boardname": [
-                    "SQUAWKS"
-                ]
+                "boardname": "SQUAWKS"
             },
             {
                 "device": [
                     "AOpen Chromebase Commercial"
                 ],
-                "boardname": [
-                    "SUMO"
-                ]
+                "boardname": "SUMO"
             },
             {
                 "device": [
                     "Toshiba Chromebook 2 (2014)"
                 ],
-                "boardname": [
-                    "SWANKY"
-                ]
+                "boardname": "SWANKY"
             },
             {
                 "device": [
                     "Samsung Chromebook 2 (XE500C12)"
                 ],
-                "boardname": [
-                    "WINKY"
-                ]
+                "boardname": "WINKY"
             }
         ]
     },
@@ -374,52 +294,40 @@
                 "device": [
                     "Acer Chromebook 15 (CB3-532)"
                 ],
-                "boardname": [
-                    "BANON"
-                ],
+                "boardname": "BANON",
                 "wpMethod": "<a href=\"/images/wp/Banon_wp.jpg\" class=\"internal\" title=\"Banon wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Samsung Chromebook 3"
                 ],
-                "boardname": [
-                    "CELES"
-                ]
+                "boardname": "CELES"
             },
             {
                 "device": [
                     "Acer Chromebook R11 (C738T, CB5-132T)"
                 ],
-                "boardname": [
-                    "CYAN"
-                ],
+                "boardname": "CYAN",
                 "wpMethod": "<a href=\"/images/wp/cyan_wp.jpg\" class=\"internal\" title=\"cyan_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Acer Chromebook 14 (CB3-431)"
                 ],
-                "boardname": [
-                    "EDGAR"
-                ],
+                "boardname": "EDGAR",
                 "wpMethod": "<a href=\"/images/wp/Edgar_wp.jpg\" class=\"internal\" title=\"Edgar wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Dell Chromebook 11 3180/3189"
                 ],
-                "boardname": [
-                    "KEFKA"
-                ]
+                "boardname": "KEFKA"
             },
             {
                 "device": [
                     "Lenovo N22/N23/N42 Chromebook"
                 ],
-                "boardname": [
-                    "REKS"
-                ]
+                "boardname": "REKS"
             },
             {
                 "device": [
@@ -431,18 +339,14 @@
                     "Mecer V2 Chromebook",
                     "Positivo Chromebook C216B"
                 ],
-                "boardname": [
-                    "RELM"
-                ],
+                "boardname": "RELM",
                 "wpMethod": "<a href=\"/images/wp/C731_wp.jpg\" class=\"internal\" title=\"C731 wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "HP Chromebook 11 G5"
                 ],
-                "boardname": [
-                    "SETZER"
-                ],
+                "boardname": "SETZER",
                 "wpMethod": "<a href=\"/images/wp/setzer_wp.png\" class=\"internal\" title=\"setzer_wp.png\" target=\"_blank\">screw</a>"
             },
             {
@@ -450,18 +354,14 @@
                     "Asus Chromebook C202S/C202SA",
                     "Asus Chromebook C300SA/C301SA"
                 ],
-                "boardname": [
-                    "TERRA"
-                ],
+                "boardname": "TERRA",
                 "wpMethod": "<a href=\"/images/wp/C202sa_wp.jpg\" class=\"internal\" title=\"C202sa wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Lenovo ThinkPad 11e/Yoga Chromebook (G3)"
                 ],
-                "boardname": [
-                    "ULTIMA"
-                ]
+                "boardname": "ULTIMA"
             },
             {
                 "device": [
@@ -473,9 +373,7 @@
                     "Prowise Chromebook Proline",
                     "Viglen Chromebook 360"
                 ],
-                "boardname": [
-                    "WIZPIG"
-                ]
+                "boardname": "WIZPIG"
             }
         ]
     },
@@ -488,51 +386,39 @@
                 "device": [
                     "Dell Chromebook 13 3380"
                 ],
-                "boardname": [
-                    "ASUKA"
-                ]
+                "boardname": "ASUKA"
             },
             {
                 "device": [
                     "Samsung Chromebook Pro"
                 ],
-                "boardname": [
-                    "CAROLINE"
-                ],
+                "boardname": "CAROLINE",
                 "wpMethod": "<a href=\"/images/wp/Caroline_wp.jpg\" class=\"internal\" title=\"Caroline_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Asus Chromebook C302CA"
                 ],
-                "boardname": [
-                    "CAVE"
-                ]
+                "boardname": "CAVE"
             },
             {
                 "device": [
                     "HP Chromebook 13 G1"
                 ],
-                "boardname": [
-                    "CHELL"
-                ]
+                "boardname": "CHELL"
             },
             {
                 "device": [
                     "Acer Chromebook 14 for Work",
                     "Acer Chromebook 11 (C771/C771T)"
                 ],
-                "boardname": [
-                    "LARS"
-                ]
+                "boardname": "LARS"
             },
             {
                 "device": [
                     "Lenovo Thinkpad 13 Chromebook"
                 ],
-                "boardname": [
-                    "SENTRY"
-                ]
+                "boardname": "SENTRY"
             }
         ]
     },
@@ -545,146 +431,127 @@
                 "device": [
                     "Acer Chromebook 11 (C732)"
                 ],
-                "boardname": [
-                    "ASTRONAUT"
-                ]
+                "boardname": "ASTRONAUT"
             },
             {
                 "device": [
                     "Asus Chromebook C223NA",
                     "ASUS Chromebook CX1100CNA"
                 ],
-                "boardname": [
-                    "BABYMEGA"
-                ]
+                "boardname": "BABYMEGA"
             },
             {
                 "device": [
                     "Asus Chromebook C523NA",
                     "ASUS Chromebook CX1500CNA"
                 ],
-                "boardname": [
-                    "BABYTIGER"
-                ]
+                "boardname": "BABYTIGER"
             },
             {
                 "device": [
-                    "CTL Chromebook NL7/NL7T",
-                    "Edxis Chromebook 11/X11",
+                    "CTL Chromebook NL7",
+                    "Edxis Chromebook 11",
                     "Lanix Chromebook C116",
                     "Multilaser Chromebook M11C-PC912",
-                    "Positivo Chromebook N2110/N2112",
+                    "Positivo Chromebook N2110"
+                ],
+                "boardname": "BLACKTIP"
+            },
+            {
+                "device": [
+                    "CTL Chromebook NL7T/NL7TW",
+                    "Edxis Chromebook X11",
+                    "Multilaser Chromebook M11HC-PC911",
+                    "Positivo Chromebook N2112",
                     "Viglen Chromebook 360C"
                 ],
-                "boardname": [
-                    "BLACKTIP"
-                ]
+                "boardname": "BLACKTIP360"
+            },
+            {
+                "device": [
+                    "CTL Chromebook NL7 LTE"
+                ],
+                "boardname": "BLACKTIPLTE"
             },
             {
                 "device": [
                     "Acer Chromebook 15 (CB315)"
                 ],
-                "boardname": [
-                    "BLUE"
-                ]
+                "boardname": "BLUE"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 15 (CP315)"
                 ],
-                "boardname": [
-                    "BRUCE"
-                ]
+                "boardname": "BRUCE"
             },
             {
                 "device": [
                     "Acer Chromebook 514 (CB514-1H, CB514-1HT)"
                 ],
-                "boardname": [
-                    "EPAULETTE"
-                ]
+                "boardname": "EPAULETTE"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 11 (CP311-1H, CP311-1HN)"
                 ],
-                "boardname": [
-                    "LAVA"
-                ]
+                "boardname": "LAVA"
             },
             {
                 "device": [
                     "Dell Chromebook 11 5190"
                 ],
-                "boardname": [
-                    "NASHER"
-                ]
+                "boardname": "NASHER"
             },
             {
                 "device": [
                     "Dell Chromebook 11 5190 2-in-1"
                 ],
-                "boardname": [
-                    "NASHER360"
-                ]
+                "boardname": "NASHER360"
             },
             {
                 "device": [
                     "Lenovo Thinkpad 11e/Yoga 11e (G4)"
                 ],
-                "boardname": [
-                    "PYRO"
-                ]
+                "boardname": "PYRO"
             },
             {
                 "device": [
                     "Asus Chromebook C423",
                     "ASUS Chromebook CX1400CNA"
                 ],
-                "boardname": [
-                    "RABBID"
-                ]
+                "boardname": "RABBID"
             },
             {
                 "device": [
                     "Asus Chromebook Flip C213SA",
                     "Acer Chromebook Spin 11 (R751T)"
                 ],
-                "boardname": [
-                    "REEF"
-                ]
+                "boardname": "REEF"
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook"
                 ],
-                "boardname": [
-                    "ROBO"
-                ]
+                "boardname": "ROBO"
             },
             {
                 "device": [
                     "Lenovo 500e Chromebook"
                 ],
-                "boardname": [
-                    "ROBO360"
-                ]
+                "boardname": "ROBO360"
             },
             {
                 "device": [
                     "Acer Chromebook 15 (CB515-1H, CB515-1HT)"
                 ],
-                "boardname": [
-                    "SAND"
-                ]
+                "boardname": "SAND"
             },
             {
                 "device": [
                     "Acer Chromebook 11 (CB311-8H, CB311-8HT)"
                 ],
-                "boardname": [
-                    "SANTA"
-                ]
+                "boardname": "SANTA"
             },
             {
                 "device": [
@@ -692,9 +559,7 @@
                     "HP Chromebook 11 G6",
                     "HP Chromebook 14 G5"
                 ],
-                "boardname": [
-                    "SNAPPY"
-                ]
+                "boardname": "SNAPPY"
             },
             {
                 "device": [
@@ -704,9 +569,7 @@
                     "Sector 5 E3 Chromebook",
                     "Viglen Chromebook 11C"
                 ],
-                "boardname": [
-                    "WHITETIP"
-                ]
+                "boardname": "WHITETIP"
             }
         ]
     },
@@ -719,66 +582,50 @@
                 "device": [
                     "Acer Chromebook 13 (CB713-1W)"
                 ],
-                "boardname": [
-                    "AKALI"
-                ]
+                "boardname": "AKALI"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 13 (CP713-1WN)"
                 ],
-                "boardname": [
-                    "AKALI360"
-                ]
+                "boardname": "AKALI360"
             },
             {
                 "device": [
                     "Google Pixelbook Go (2019)"
                 ],
-                "boardname": [
-                    "ATLAS"
-                ]
+                "boardname": "ATLAS"
             },
             {
                 "device": [
                     "Acer Chromebook 715 (CB715)"
                 ],
-                "boardname": [
-                    "BARD"
-                ]
+                "boardname": "BARD"
             },
             {
                 "device": [
                     "Acer Chromebook 714 (CB714)"
                 ],
-                "boardname": [
-                    "EKKO"
-                ]
+                "boardname": "EKKO"
             },
             {
                 "device": [
                     "Meet Compute System - Series One (Lenovo)"
                 ],
-                "boardname": [
-                    "ENDEAVOUR"
-                ],
+                "boardname": "ENDEAVOUR",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Excelsior_wp.jpg\" class=\"internal\" title=\"Excelsior wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Google Pixelbook (2017)"
                 ],
-                "boardname": [
-                    "EVE"
-                ]
+                "boardname": "EVE"
             },
             {
                 "device": [
                     "Asus Google Meet kit (KBL)"
                 ],
-                "boardname": [
-                    "EXCELSIOR"
-                ],
+                "boardname": "EXCELSIOR",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Excelsior_wp.jpg\" class=\"internal\" title=\"Excelsior wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
@@ -786,118 +633,90 @@
                     "AOpen Chromebox Commercial 2",
                     "Newline Chromebox A10"
                 ],
-                "boardname": [
-                    "JAX"
-                ],
+                "boardname": "JAX",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/fizz_wp.jpg\" class=\"internal\" title=\"fizz wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Acer Chromebase 24I2"
                 ],
-                "boardname": [
-                    "KARMA"
-                ],
+                "boardname": "KARMA",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, screw"
             },
             {
                 "device": [
                     "HP Chromebox G2"
                 ],
-                "boardname": [
-                    "KENCH"
-                ],
+                "boardname": "KENCH",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/fizz_wp.jpg\" class=\"internal\" title=\"fizz wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Asus Chromebook C425"
                 ],
-                "boardname": [
-                    "LEONA"
-                ]
+                "boardname": "LEONA"
             },
             {
                 "device": [
                     "Samsung Chromebook Plus V2"
                 ],
-                "boardname": [
-                    "NAUTILUS"
-                ]
+                "boardname": "NAUTILUS"
             },
             {
                 "device": [
                     "Google Pixel Slate"
                 ],
-                "boardname": [
-                    "NOCTURNE"
-                ]
+                "boardname": "NOCTURNE"
             },
             {
                 "device": [
                     "Lenovo Yoga Chromebook C630"
                 ],
-                "boardname": [
-                    "PANTHEON"
-                ]
+                "boardname": "PANTHEON"
             },
             {
                 "device": [
                     "Asus Chromebook Flip C433/C434"
                 ],
-                "boardname": [
-                    "SHYVANA"
-                ]
+                "boardname": "SHYVANA"
             },
             {
                 "device": [
                     "Acer Chromebox CXI3"
                 ],
-                "boardname": [
-                    "SION"
-                ],
+                "boardname": "SION",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/fizz_wp.jpg\" class=\"internal\" title=\"fizz wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "HP Chromebook x360 14"
                 ],
-                "boardname": [
-                    "SONA"
-                ]
+                "boardname": "SONA"
             },
             {
                 "device": [
                     "HP Chromebook X2"
                 ],
-                "boardname": [
-                    "SORAKA"
-                ]
+                "boardname": "SORAKA"
             },
             {
                 "device": [
                     "HP Chromebook 15 G1"
                 ],
-                "boardname": [
-                    "SYNDRA"
-                ]
+                "boardname": "SYNDRA"
             },
             {
                 "device": [
                     "Asus Chromebox 3 (CN65)"
                 ],
-                "boardname": [
-                    "TEEMO"
-                ],
+                "boardname": "TEEMO",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/fizz_wp.jpg\" class=\"internal\" title=\"fizz wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
                 "device": [
                     "Dell Inspiron Chromebook 14 (7460)"
                 ],
-                "boardname": [
-                    "VAYNE"
-                ]
+                "boardname": "VAYNE"
             },
             {
                 "device": [
@@ -906,9 +725,7 @@
                     "SMART Chromebox G3",
                     "ViewSonic NMP660 Chromebox"
                 ],
-                "boardname": [
-                    "WUKONG"
-                ],
+                "boardname": "WUKONG",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/fizz_wp.jpg\" class=\"internal\" title=\"fizz wp.jpg\" target=\"_blank\">screw</a>"
             }
         ]
@@ -922,133 +739,101 @@
                 "device": [
                     "Asus Chromebook Flip C214/C234"
                 ],
-                "boardname": [
-                    "AMPTON"
-                ]
+                "boardname": "AMPTON"
             },
             {
                 "device": [
                     "Asus Chromebook Flip C204"
                 ],
-                "boardname": [
-                    "APEL"
-                ]
+                "boardname": "APEL"
             },
             {
                 "device": [
                     "HP Chromebook x360 12b-ca0"
                 ],
-                "boardname": [
-                    "BLOOG"
-                ]
+                "boardname": "BLOOG"
             },
             {
                 "device": [
                     "HP Chromebook 14a-na0"
                 ],
-                "boardname": [
-                    "BLOOGLET"
-                ]
+                "boardname": "BLOOGLET"
             },
             {
                 "device": [
                     "HP Chromebook x360 14a-ca0/14b-ca0"
                 ],
-                "boardname": [
-                    "BLOOGUARD"
-                ]
+                "boardname": "BLOOGUARD"
             },
             {
                 "device": [
                     "Acer Chromebook 315 (CB315-3H, CB315-3HT)"
                 ],
-                "boardname": [
-                    "BLORB"
-                ]
+                "boardname": "BLORB"
             },
             {
                 "device": [
                     "Samsung Chromebook 4"
                 ],
-                "boardname": [
-                    "BLUEBIRD"
-                ]
+                "boardname": "BLUEBIRD"
             },
             {
                 "device": [
                     "Acer Chromebook 311",
                     "(CB311-9H, CB311-9HT, C733, C733U, C733T)"
                 ],
-                "boardname": [
-                    "BOBBA"
-                ]
+                "boardname": "BOBBA"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 311 (CP311-2H, CP311-2HN)",
                     "Acer Chromebook Spin 511 (R752T, R752TN)"
                 ],
-                "boardname": [
-                    "BOBBA360"
-                ]
+                "boardname": "BOBBA360"
             },
             {
                 "device": [
                     "Samsung Chromebook 4+"
                 ],
-                "boardname": [
-                    "CASTA"
-                ]
+                "boardname": "CASTA"
             },
             {
                 "device": [
                     "NEC Chromebook Y2"
                 ],
-                "boardname": [
-                    "DOOD"
-                ]
+                "boardname": "DOOD"
             },
             {
                 "device": [
                     "HP Chromebook 14 G6"
                 ],
-                "boardname": [
-                    "DORP"
-                ]
+                "boardname": "DORP"
             },
             {
                 "device": [
                     "Acer Chromebook 314 (C933, C933T, CB314-1H, CB314-1HT)",
                     "Packard Bell Chromebook 314 (PCB314)"
                 ],
-                "boardname": [
-                    "DROID"
-                ]
+                "boardname": "DROID"
             },
             {
                 "device": [
                     "Dell Chromebook 3100"
                 ],
-                "boardname": [
-                    "FLEEX"
-                ]
+                "boardname": "FLEEX"
             },
             {
                 "device": [
                     "CTL Chromebook VX11/VX11T",
                     "Poin2 Chromebook 11P"
                 ],
-                "boardname": [
-                    "FOOB"
-                ]
+                "boardname": "FOOB"
             },
             {
                 "device": [
                     "Poin2 Chromebook 11P"
                 ],
-                "boardname": [
-                    "FOOB360"
-                ]
+                "boardname": "FOOB360"
             },
             {
                 "device": [
@@ -1067,9 +852,7 @@
                     "WS Chromebook A101",
                     "Zyrex Chromebook M432"
                 ],
-                "boardname": [
-                    "GARG"
-                ]
+                "boardname": "GARG"
             },
             {
                 "device": [
@@ -1087,82 +870,62 @@
                     "WS Chromebook A101",
                     "Zyrex Chromebook 360"
                 ],
-                "boardname": [
-                    "GARG360"
-                ]
+                "boardname": "GARG360"
             },
             {
                 "device": [
                     "CTL Chromebook NL81/NL81T"
                 ],
-                "boardname": [
-                    "GARFOUR"
-                ]
+                "boardname": "GARFOUR"
             },
             {
                 "device": [
                     "Dell Chromebook 3100 2-in-1"
                 ],
-                "boardname": [
-                    "GRABBITER"
-                ]
+                "boardname": "GRABBITER"
             },
             {
                 "device": [
                     "Lenovo Chromebook S340",
                     "Lenovo IdeaPad Flex 3 Chromebook 14\""
                 ],
-                "boardname": [
-                    "LASER14"
-                ]
+                "boardname": "LASER14"
             },
             {
                 "device": [
                     "Lenovo Ideapad 3 Chromebook"
                 ],
-                "boardname": [
-                    "LICK"
-                ]
+                "boardname": "LICK"
             },
             {
                 "device": [
                     "HP Chromebook x360 11 G2 EE"
                 ],
-                "boardname": [
-                    "MEEP"
-                ]
+                "boardname": "MEEP"
             },
             {
                 "device": [
                     "HP Chromebook 11 G7 EE"
                 ],
-                "boardname": [
-                    "MIMROCK"
-                ]
+                "boardname": "MIMROCK"
             },
             {
                 "device": [
                     "Asus Chromebook C424"
                 ],
-                "boardname": [
-                    "NOSPIKE"
-                ]
+                "boardname": "NOSPIKE"
             },
             {
                 "device": [
                     "Dell Chromebook 3400"
                 ],
-                "boardname": [
-                    "ORBATRIX"
-                ]
+                "boardname": "ORBATRIX"
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook Gen 2"
                 ],
-                "boardname": [
-                    "PHASER"
-                ]
+                "boardname": "PHASER"
             },
             {
                 "device": [
@@ -1172,41 +935,31 @@
                     "Lenovo IdeaPad Flex 3 Chromebook 11\"",
                     "NEC Chromebook Y1"
                 ],
-                "boardname": [
-                    "PHASER360"
-                ]
+                "boardname": "PHASER360"
             },
             {
                 "device": [
                     "Acer Chromebook 512 (C851/C851T)"
                 ],
-                "boardname": [
-                    "SPARKY"
-                ]
+                "boardname": "SPARKY"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 512 (R851TN)"
                 ],
-                "boardname": [
-                    "SPARKY360"
-                ]
+                "boardname": "SPARKY360"
             },
             {
                 "device": [
                     "HP Chromebook 11 G8 EE"
                 ],
-                "boardname": [
-                    "VORTICON"
-                ]
+                "boardname": "VORTICON"
             },
             {
                 "device": [
                     "HP Chromebook x360 11 G3 EE"
                 ],
-                "boardname": [
-                    "VORTININJA"
-                ]
+                "boardname": "VORTININJA"
             }
         ]
     },
@@ -1219,17 +972,13 @@
                 "device": [
                     "Dell Latitude 5300 2-in-1 Chromebook Enterprise"
                 ],
-                "boardname": [
-                    "ARCADA"
-                ]
+                "boardname": "ARCADA"
             },
             {
                 "device": [
                     "Dell Latitude 5400 Chromebook Enterprise"
                 ],
-                "boardname": [
-                    "SARIEN"
-                ]
+                "boardname": "SARIEN"
             }
         ]
     },
@@ -1242,27 +991,21 @@
                 "device": [
                     "Lenovo Ideapad Flex 5 Chromebook"
                 ],
-                "boardname": [
-                    "AKEMI"
-                ]
+                "boardname": "AKEMI"
             },
             {
                 "device": [
                     "ASUS Meet Compute System (Intel 10th Gen)",
                     "CTL Meet Compute System (Intel 10th Gen)"
                 ],
-                "boardname": [
-                    "AMBASSADOR"
-                ],
+                "boardname": "AMBASSADOR",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, jumper"
             },
             {
                 "device": [
                     "HP Chromebase 21.5\""
                 ],
-                "boardname": [
-                    "DOOLY"
-                ],
+                "boardname": "DOOLY",
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, jumper"
             },
@@ -1270,43 +1013,33 @@
                 "device": [
                     "HP Chromebook x360 14c-ca0"
                 ],
-                "boardname": [
-                    "DRAGONAIR"
-                ]
+                "boardname": "DRAGONAIR"
             },
             {
                 "device": [
                     "Dell Latitude 7410 Chromebook Enterprise"
                 ],
-                "boardname": [
-                    "DRALLION"
-                ],
+                "boardname": "DRALLION",
                 "rwLegacy": true
             },
             {
                 "device": [
                     "Dell Latitude 7410 2-in-1 Chromebook Enterprise"
                 ],
-                "boardname": [
-                    "DRALLION360"
-                ],
+                "boardname": "DRALLION360",
                 "rwLegacy": true
             },
             {
                 "device": [
                     "HP Pro c640 Chromebook"
                 ],
-                "boardname": [
-                    "DRATINI"
-                ]
+                "boardname": "DRATINI"
             },
             {
                 "device": [
                     "Asus Chromebox 4"
                 ],
-                "boardname": [
-                    "DUFFY"
-                ],
+                "boardname": "DUFFY",
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Duffy_wp_jumper.png\" class=\"internal\" title=\"Duffy wp jumper.png\" target=\"_blank\">jumper</a>"
             },
@@ -1314,9 +1047,7 @@
                 "device": [
                     "Asus Fanless Chromebox"
                 ],
-                "boardname": [
-                    "FAFFY"
-                ],
+                "boardname": "FAFFY",
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, jumper"
             },
@@ -1324,35 +1055,27 @@
                 "device": [
                     "Meet Compute System - Series One (Intel 10th Gen)"
                 ],
-                "boardname": [
-                    "GENESIS"
-                ],
+                "boardname": "GENESIS",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, jumper"
             },
             {
                 "device": [
                     "Asus Chromebook Flip C436FA"
                 ],
-                "boardname": [
-                    "HELIOS"
-                ]
+                "boardname": "HELIOS"
             },
             {
                 "device": [
                     "HP Elite c1030 Chromebook",
                     "HP Chromebook x360 13c-ca0"
                 ],
-                "boardname": [
-                    "JINLON"
-                ]
+                "boardname": "JINLON"
             },
             {
                 "device": [
                     "Acer Chromebox CXI4"
                 ],
-                "boardname": [
-                    "KAISA"
-                ],
+                "boardname": "KAISA",
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Kaisa_wp.jpg\" class=\"internal\" title=\"Kaisa_wp.jpg\" target=\"_blank\">jumper</a>"
             },
@@ -1360,41 +1083,31 @@
                 "device": [
                     "Acer Chromebook 712 (C871)"
                 ],
-                "boardname": [
-                    "KINDRED"
-                ]
+                "boardname": "KINDRED"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 713 (CP713-2W)"
                 ],
-                "boardname": [
-                    "KLED"
-                ]
+                "boardname": "KLED"
             },
             {
                 "device": [
                     "Samsung Galaxy Chromebook"
                 ],
-                "boardname": [
-                    "KOHAKU"
-                ]
+                "boardname": "KOHAKU"
             },
             {
                 "device": [
                     "Samsung Galaxy Chromebook 2"
                 ],
-                "boardname": [
-                    "NIGHTFURY"
-                ]
+                "boardname": "NIGHTFURY"
             },
             {
                 "device": [
                     "HP Chromebox G3"
                 ],
-                "boardname": [
-                    "NOIBAT"
-                ],
+                "boardname": "NOIBAT",
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Noibat_wp.png\" class=\"internal\" title=\"Noibat wp.png\" target=\"_blank\">jumper</a>"
             },
@@ -1404,9 +1117,7 @@
                     "Promethean Chromebox 2",
                     "ViewSonic NMP760 Chromebox"
                 ],
-                "boardname": [
-                    "WYVERN"
-                ],
+                "boardname": "WYVERN",
                 "rwLegacy": true,
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Wyvern_WP_jumper.png\" class=\"internal\" title=\"Wyvern WP jumper.png\" target=\"_blank\">jumper</a>"
             }
@@ -1421,107 +1132,81 @@
                 "device": [
                     "FMV Chromebook 14F"
                 ],
-                "boardname": [
-                    "CHRONICLER"
-                ]
+                "boardname": "CHRONICLER"
             },
             {
                 "device": [
                     "Asus Chromebook Flip CX3"
                 ],
-                "boardname": [
-                    "COLLIS"
-                ]
+                "boardname": "COLLIS"
             },
             {
                 "device": [
                     "Asus Chromebook Flip CX5 (CX5400)"
                 ],
-                "boardname": [
-                    "COPANO"
-                ]
+                "boardname": "COPANO"
             },
             {
                 "device": [
                     "Asus Chromebook Flip CX55, CX5 (CX5500), C536"
                 ],
-                "boardname": [
-                    "DELBIN"
-                ]
+                "boardname": "DELBIN"
             },
             {
                 "device": [
                     "Asus Chromebook CX9 (CX9400)"
                 ],
-                "boardname": [
-                    "DROBIT"
-                ]
+                "boardname": "DROBIT"
             },
             {
                 "device": [
                     "HP Chromebook x360 14c-cc0"
                 ],
-                "boardname": [
-                    "ELDRID"
-                ]
+                "boardname": "ELDRID"
             },
             {
                 "device": [
                     "HP Pro c640 G2 Chromebook",
                     "HP Chromebook 14b-nb0"
                 ],
-                "boardname": [
-                    "ELEMI"
-                ]
+                "boardname": "ELEMI"
             },
             {
                 "device": [
                     "Lenovo IdeaPad Flex 5i Chromebook"
                 ],
-                "boardname": [
-                    "LILLIPUP"
-                ]
+                "boardname": "LILLIPUP"
             },
             {
                 "device": [
                     "Lenovo 5i-14 Chromebook",
                     "Lenovo Slim 5 Chromebook"
                 ],
-                "boardname": [
-                    "LINDAR"
-                ]
+                "boardname": "LINDAR"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 514 (CP514-2H)"
                 ],
-                "boardname": [
-                    "VOEMA"
-                ]
+                "boardname": "VOEMA"
             },
             {
                 "device": [
                     "Acer Chromebook 515 (CB515-1W, CB515-1WT)"
                 ],
-                "boardname": [
-                    "VOLET"
-                ]
+                "boardname": "VOLET"
             },
             {
                 "device": [
                     "Acer Chromebook 514 (CB514-1W, CB514-1WT)"
                 ],
-                "boardname": [
-                    "VOLTA"
-                ]
+                "boardname": "VOLTA"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 713 (CP713-3W)"
                 ],
-                "boardname": [
-                    "VOXEL"
-                ]
+                "boardname": "VOXEL"
             }
         ]
     },
@@ -1536,186 +1221,142 @@
                     "Multilaser Chromebook M11C-PC919",
                     "Allied Chromebook 11 N5100E"
                 ],
-                "boardname": [
-                    "BEADRIX"
-                ]
+                "boardname": "BEADRIX"
             },
             {
                 "device": [
                     "Lenovo Flex 3i 15 / Ideapad Flex 3i Chromebook"
                 ],
-                "boardname": [
-                    "BEETLEY"
-                ]
+                "boardname": "BEETLEY"
             },
             {
                 "device": [
                     "Lenovo 3i-15 Chromebook"
                 ],
-                "boardname": [
-                    "BLIPPER"
-                ]
+                "boardname": "BLIPPER"
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook Gen 3"
                 ],
-                "boardname": [
-                    "BOOKEM"
-                ],
+                "boardname": "BOOKEM",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Boten_wp.jpg\" class=\"internal\" title=\"Boten wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Lenovo 500e Chromebook Gen 3"
                 ],
-                "boardname": [
-                    "BOTEN"
-                ],
+                "boardname": "BOTEN",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Boten_wp.jpg\" class=\"internal\" title=\"Boten wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Lenovo Flex 3i-11 / IdeaPad Flex 3i Chromebook"
                 ],
-                "boardname": [
-                    "BOTENFLEX"
-                ],
+                "boardname": "BOTENFLEX",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Boten_wp.jpg\" class=\"internal\" title=\"Boten wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Samsung Galaxy Chromebook 2 360"
                 ],
-                "boardname": [
-                    "BUGZZY"
-                ]
+                "boardname": "BUGZZY"
             },
             {
                 "device": [
                     "Dell Chromebook 3110"
                 ],
-                "boardname": [
-                    "CRET"
-                ],
+                "boardname": "CRET",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Cret_jumper.jpg\" class=\"internal\" title=\"Cret_jumper.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Dell Chromebook 3110 2-in-1"
                 ],
-                "boardname": [
-                    "CRET360"
-                ]
+                "boardname": "CRET360"
             },
             {
                 "device": [
                     "AOPEN Chromebox Mini 2"
                 ],
-                "boardname": [
-                    "DEXI"
-                ]
+                "boardname": "DEXI"
             },
             {
                 "device": [
                     "Acer Chromebox Mini CXM1"
                 ],
-                "boardname": [
-                    "DITA"
-                ]
+                "boardname": "DITA"
             },
             {
                 "device": [
                     "HP Chromebook x360 11 G4 EE",
                     "HP Fortis x360 11 G3 J Chromebook"
                 ],
-                "boardname": [
-                    "DRAWCIA"
-                ],
+                "boardname": "DRAWCIA",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Drawcia_wp.jpg\" class=\"internal\" title=\"Drawcia wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "HP Chromebook 11 G9 EE"
                 ],
-                "boardname": [
-                    "DRAWLAT"
-                ],
+                "boardname": "DRAWLAT",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Drawlat_wp.jpg\" class=\"internal\" title=\"Drawlat wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "HP Chromebook 14 G7"
                 ],
-                "boardname": [
-                    "DRAWMAN"
-                ],
+                "boardname": "DRAWMAN",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Drawman_wp.jpg\" class=\"internal\" title=\"Drawman wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "HP Fortis 14 G10 Chromebook"
                 ],
-                "boardname": [
-                    "DRAWPER"
-                ],
+                "boardname": "DRAWPER",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Drawman_wp.jpg\" class=\"internal\" title=\"Drawman wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Asus Chromebook CX1500CKA"
                 ],
-                "boardname": [
-                    "GALITH"
-                ]
+                "boardname": "GALITH"
             },
             {
                 "device": [
                     "Asus Chromebook CX1500FKA"
                 ],
-                "boardname": [
-                    "GALITH360"
-                ]
+                "boardname": "GALITH360"
             },
             {
                 "device": [
                     "Asus Chromebook CX1700CKA"
                 ],
-                "boardname": [
-                    "GALLOP"
-                ]
+                "boardname": "GALLOP"
             },
             {
                 "device": [
                     "Asus Chromebook CX1 CX1102"
                 ],
-                "boardname": [
-                    "GALNAT"
-                ]
+                "boardname": "GALNAT"
             },
             {
                 "device": [
                     "Asus Chromebook Flip CX1 CX1102"
                 ],
-                "boardname": [
-                    "GALNAT360"
-                ]
+                "boardname": "GALNAT360"
             },
             {
                 "device": [
                     "Asus Chromebook CX1"
                 ],
-                "boardname": [
-                    "GALTIC"
-                ]
+                "boardname": "GALTIC"
             },
             {
                 "device": [
                     "Asus Chromebook CX1400FKA"
                 ],
-                "boardname": [
-                    "GALTIC360"
-                ]
+                "boardname": "GALTIC360"
             },
             {
                 "device": [
@@ -1726,9 +1367,7 @@
                     "Poin2 Chromebook 11B",
                     "Zyrex Chromebook M432-64"
                 ],
-                "boardname": [
-                    "KRACKO"
-                ]
+                "boardname": "KRACKO"
             },
             {
                 "device": [
@@ -1736,76 +1375,58 @@
                     "LG Chromebook 11TC50Q/11TQ50Q",
                     "Poin2 Chromebook 11E"
                 ],
-                "boardname": [
-                    "KRACKO360"
-                ]
+                "boardname": "KRACKO360"
             },
             {
                 "device": [
                     "HP Chromebook x360 14a-ca1"
                 ],
-                "boardname": [
-                    "LANDIA"
-                ]
+                "boardname": "LANDIA"
             },
             {
                 "device": [
                     "HP Chromebook 15a-na0"
                 ],
-                "boardname": [
-                    "LANDRID"
-                ],
+                "boardname": "LANDRID",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Landrid_wp.jpg\" class=\"internal\" title=\"Landrid wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "HP Chromebook 14a-na1"
                 ],
-                "boardname": [
-                    "LANTIS"
-                ],
+                "boardname": "LANTIS",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Lantis_wp.jpg\" class=\"internal\" title=\"Lantis wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "HP Chromebook x360 14b-cb0"
                 ],
-                "boardname": [
-                    "MADOO"
-                ]
+                "boardname": "MADOO"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 314 [CP314-1H, CP314-1HN]"
                 ],
-                "boardname": [
-                    "MAGISTER"
-                ]
+                "boardname": "MAGISTER"
             },
             {
                 "device": [
                     "Acer Chromebook 512 [C852]"
                 ],
-                "boardname": [
-                    "MAGLET"
-                ]
+                "boardname": "MAGLET"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 512 [R853TA/R853TNA]"
                 ],
-                "boardname": [
-                    "MAGLIA"
-                ],
+                "boardname": "MAGLIA",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Maglia_wp.jpg\" class=\"internal\" title=\"Maglia wp.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Acer Chromebook 511 [C733/C734]"
                 ],
-                "boardname": [
-                    "MAGLITH"
-                ],
+                "boardname": "MAGLITH",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Maglith_wp.jpg\" class=\"internal\" title=\"Maglith wp.jpg\" target=\"_blank\">jumper</a>"
             
             },
@@ -1813,9 +1434,7 @@
                 "device": [
                     "Acer Chromebook 315 [CB315-4H/4HT]"
                 ],
-                "boardname": [
-                    "MAGMA"
-                ],
+                "boardname": "MAGMA",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/magma_wp_jumper.jpg\" class=\"internal\" title=\"magma_wp_jumper\" target=\"_blank\">jumper</a>"
             },
             {
@@ -1823,43 +1442,33 @@
                     "Acer Chromebook 314 [CB314-3H/3HT, C934/C934T]",
                     "Packard Bell Chromebook 314"
                 ],
-                "boardname": [
-                    "MAGNETO"
-                ]
+                "boardname": "MAGNETO"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 511 [R753T]"
                 ],
-                "boardname": [
-                    "MAGOLOR"
-                ]
+                "boardname": "MAGOLOR"
             },
             {
                 "device": [
                     "Acer Chromebook 317 [CB317-1H]"
                 ],
-                "boardname": [
-                    "MAGPIE"
-                ],
+                "boardname": "MAGPIE",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Magpie_wp_jumper.png\" class=\"internal\" title=\"Magpie wp jumper.png\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "NEC Chromebook Y3"
                 ],
-                "boardname": [
-                    "METAKNIGHT"
-                ],
+                "boardname": "METAKNIGHT",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/Magpie_wp_jumper.png\" class=\"internal\" title=\"Magpie wp jumper.png\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Gateway Chromebook 15"
                 ],
-                "boardname": [
-                    "PASARA"
-                ]
+                "boardname": "PASARA"
             },
             {
                 "device": [
@@ -1869,9 +1478,7 @@
                     "Edxis E-Lite Chromebook 11",
                     "Multilaser Chromebook M11C-PC924"
                 ],
-                "boardname": [
-                    "PEEZER"
-                ]
+                "boardname": "PEEZER"
             },
             {
                 "device": [
@@ -1880,9 +1487,7 @@
                     "SPC Chromebook Z1 Mini",
                     "Zyrex Chromebook M432-2"
                 ],
-                "boardname": [
-                    "PIRETTE"
-                ]
+                "boardname": "PIRETTE"
             },
             {
                 "device": [
@@ -1890,51 +1495,39 @@
                     "CTL Chromebook Enterprise",
                     "Gateway Chromebook 14"
                 ],
-                "boardname": [
-                    "PIRIKA"
-                ]
+                "boardname": "PIRIKA"
             },
             {
                 "device": [
                     "Samsung Galaxy Chromebook Go"
                 ],
-                "boardname": [
-                    "SASUKE"
-                ]
+                "boardname": "SASUKE"
             },
             {
                 "device": [
                     "SamsungGalaxy Chromebook Go 11"
                 ],
-                "boardname": [
-                    "SASUKETTE"
-                ]
+                "boardname": "SASUKETTE"
             },
             {
                 "device": [
                     "Asus Chromebook CR1100CKA"
                 ],
-                "boardname": [
-                    "STORO"
-                ],
+                "boardname": "STORO",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/storo_wp_jumper.jpg\" class=\"internal\" title=\"storo_wp_jumper\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "Asus Chromebook Flip CR1100FKA"
                 ],
-                "boardname": [
-                    "STORO360"
-                ],
+                "boardname": "STORO360",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50</a>, <a href=\"/images/wp/storo_wp_jumper.jpg\" class=\"internal\" title=\"storo_wp_jumper\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
                     "ASUS Fanless Chromebox CF40"
                 ],
-                "boardname": [
-                    "TARANZA"
-                ]
+                "boardname": "TARANZA"
             }
         ]
     },
@@ -1947,147 +1540,111 @@
                 "device": [
                     "HP Elite c640 14 inch G3 Chromebook"
                 ],
-                "boardname": [
-                    "ANAHERA"
-                ]
+                "boardname": "ANAHERA"
             },
             {
                 "device": [
                     "AOpen Chromebox Commercial 3"
                 ],
-                "boardname": [
-                    "AURASH"
-                ]
+                "boardname": "AURASH"
             },
             {
                 "device": [
                     "Framework Laptop Chromebook Edition"
                 ],
-                "boardname": [
-                    "BANSHEE"
-                ]
+                "boardname": "BANSHEE"
             },
             {
                 "device": [
                     "Dell Latitude 5430 Chromebook"
                 ],
-                "boardname": [
-                    "CROTA"
-                ]
+                "boardname": "CROTA"
             },
             {
                 "device": [
                     "Dell Latitude 5430 2-in-1 Chromebook"
                 ],
-                "boardname": [
-                    "CROTA360"
-                ]
+                "boardname": "CROTA360"
             },
             {
                 "device": [
                     "Acer Chromebook Plus Spin 514 [CP514-4HN]"
                 ],
-                "boardname": [
-                    "DOCHI"
-                ]
+                "boardname": "DOCHI"
             },
             {
                 "device": [
                     "Asus Chromebook Flip CX5 (CX5601)"
                 ],
-                "boardname": [
-                    "FELWINTER"
-                ]
+                "boardname": "FELWINTER"
             },
             {
                 "device": [
                     "HP Chromebook x360 14c-cd0"
                 ],
-                "boardname": [
-                    "GIMBLE"
-                ]
+                "boardname": "GIMBLE"
             },
             {
                 "device": [
                     "HP Chromebox Enterprise G4"
                 ],
-                "boardname": [
-                    "GLADIOS"
-                ]
+                "boardname": "GLADIOS"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 714 [CP714-1WN/2WN]"
                 ],
-                "boardname": [
-                    "KANO"
-                ]
+                "boardname": "KANO"
             },
             {
                 "device": [
                     "Lenovo ThinkCentre M60q Chromebox"
                 ],
-                "boardname": [
-                    "KINOX"
-                ]
+                "boardname": "KINOX"
             },
             {
                 "device": [
                     "ASUS Chromebox 5 (CN67)"
                 ],
-                "boardname": [
-                    "KULDAX"
-                ]
+                "boardname": "KULDAX"
             },
             {
                 "device": [
                     "CTL Chromebox CBx3"
                 ],
-                "boardname": [
-                    "LISBON"
-                ]
+                "boardname": "LISBON"
             },
             {
                 "device": [
                     "ASUS Chromebook Plus CX34"
                 ],
-                "boardname": [
-                    "MARASOV"
-                ]
+                "boardname": "MARASOV"
             },
             {
                 "device": [
                     "Asus Chromebook CX34 Flip",
                     "Asus Chromebook Vibe CX34 Flip"
                 ],
-                "boardname": [
-                    "MITHRAX"
-                ]
+                "boardname": "MITHRAX"
             },
             {
                 "device": [
                     "Acer Chromebox CXI5"
                 ],
-                "boardname": [
-                    "MOLI"
-                ]
+                "boardname": "MOLI"
             },
             {
                 "device": [
                     "Acer Chromebook Plus 515 (CB515-2H, CB515-2HT)"
                 ],
-                "boardname": [
-                    "OMNIGUL"
-                ],
+                "boardname": "OMNIGUL",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
             },
             {
                 "device": [
                     "Acer Chromebook Plus Enterprise 515 (CBE595-2/CBE595-2T)"
                 ],
-                "boardname": [
-                    "ONMIKNIGHT"
-                ],
+                "boardname": "ONMIKNIGHT",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
             },
             {
@@ -2095,74 +1652,56 @@
                     "Acer Chromebook 516 GE [CBG516-1H]",
                     "Acer Chromebook Plus 516 GE [CBG516-2H]"
                 ],
-                "boardname": [
-                    "OSIRIS"
-                ],
+                "boardname": "OSIRIS",
                 "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
             },
             {
                 "device": [
                     "Lenovo ThinkPad C14 Gen 1 Chromebook"
                 ],
-                "boardname": [
-                    "PRIMUS"
-                ]
+                "boardname": "PRIMUS"
             },
             {
                 "device": [
                     "HP Elite Dragonfly Chromebook"
                 ],
-                "boardname": [
-                    "REDRIX"
-                ]
+                "boardname": "REDRIX"
             },
             {
                 "device": [
                     "Lenovo Flex 5i Chromebook / IdeaPad Flex 5i Chromebook"
                 ],
-                "boardname": [
-                    "TAEKO"
-                ]
+                "boardname": "TAEKO"
             },
             {
                 "device": [
                     "Lenovo IdeaPad Gaming Chromebook 16"
                 ],
-                "boardname": [
-                    "TANIKS"
-                ]
+                "boardname": "TANIKS"
             },
             {
                 "device": [
                     "Lenovo 5i Chromebook 16\""
                 ],
-                "boardname": [
-                    "TARLO"
-                ]
+                "boardname": "TARLO"
             },
             {
                 "device": [
                     "HP Dragonfly Pro Chromebook"
                 ],
-                "boardname": [
-                    "VELL"
-                ]
+                "boardname": "VELL"
             },
             {
                 "device": [
                     "Acer Chromebook Vero 514 (CBV514-1H, CBV514-1HT)"
                 ],
-                "boardname": [
-                    "VOLMAR"
-                ]
+                "boardname": "VOLMAR"
             },
             {
                 "device": [
                     "Acer Chromebook Vero 712 (CV872, CV872T)"
                 ],
-                "boardname": [
-                    "ZAVALA"
-                ]
+                "boardname": "ZAVALA"
             }
         ]
     },
@@ -2175,57 +1714,43 @@
                 "device": [
                     "ASUS Chromebook CR12"
                 ],
-                "boardname": [
-                    "ANRAGGAR"
-                ]
+                "boardname": "ANRAGGAR"
             },
             {
                 "device": [
                     "ASUS Chromebook CR12 Flip"
                 ],
-                "boardname": [
-                    "ANRAGGAR360"
-                ]
+                "boardname": "ANRAGGAR360"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 512 (R856T, R856LT)"
                 ],
-                "boardname": [
-                    "CRAASK"
-                ]
+                "boardname": "CRAASK"
             },
             {
                 "device": [
                     "Acer Chromebook 311"
                 ],
-                "boardname": [
-                    "CRAASKANA"
-                ]
+                "boardname": "CRAASKANA"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 511 (R756T, R756LT)"
                 ],
-                "boardname": [
-                    "CRAASKBOWL"
-                ]
+                "boardname": "CRAASKBOWL"
             },
             {
                 "device": [
                     "Acer Chromebook 315 (CB315-5H, CB315-5HT)"
                 ],
-                "boardname": [
-                    "CRAASKINO"
-                ]
+                "boardname": "CRAASKINO"
             },
             {
                 "device": [
                     "Acer Chromebook 511 (C736, C736T, C736L, C736LT)"
                 ],
-                "boardname": [
-                    "CRAASKVIN"
-                ]
+                "boardname": "CRAASKVIN"
             },
             {
                 "device": [
@@ -2233,146 +1758,110 @@
                     "Acer Chromebook 314 (CB314-4H, CB314-4HT)",
                     "Acer Chromebook Plus 514 (CB514-4H, CB514-4HT)"
                 ],
-                "boardname": [
-                    "CRAASNETO"
-                ]
+                "boardname": "CRAASNETO"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 314 (CP314-2H, CP314-2HN)"
                 ],
-                "boardname": [
-                    "CRAASWELL"
-                ]
+                "boardname": "CRAASWELL"
             },
             {
                 "device": [
                     "HP Chromebook Plus x360"
                 ],
-                "boardname": [
-                    "JOXER"
-                ]
+                "boardname": "JOXER"
             },
             {
                 "device": [
                     "Lenovo 500e Yoga Chromebook Gen 4",
                     "Lenovo Flex 3i Chromebook 12\" / IdeaPad Flex 3i Chromebook 12\""
                 ],
-                "boardname": [
-                    "PUJJO"
-                ]
+                "boardname": "PUJJO"
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook Gen 4"
                 ],
-                "boardname": [
-                    "PUJJO1E"
-                ]
+                "boardname": "PUJJO1E"
             },
             {
                 "device": [
                     "Lenovo 14e Chromebook Gen 3"
                 ],
-                "boardname": [
-                    "PUJJOTEEN"
-                ]
+                "boardname": "PUJJOTEEN"
             },
             {
                 "device": [
                     "Lenovo Ideapad Slim 3i Chromebook"
                 ],
-                "boardname": [
-                    "PUJJOTEEN15W"
-                ]
+                "boardname": "PUJJOTEEN15W"
             },
             {
                 "device": [
                     "CTL Chromebook NL73"
                 ],
-                "boardname": [
-                    "QUANDISO"
-                ]
+                "boardname": "QUANDISO"
             },
             {
                 "device": [
                     "CTL Chromebook NL73T"
                 ],
-                "boardname": [
-                    "QUANDISO360"
-                ]
+                "boardname": "QUANDISO360"
             },
             {
                 "device": [
                     "Dell Chromebook 3120"
                 ],
-                "boardname": [
-                    "ULDREN"
-                ]
+                "boardname": "ULDREN"
             },
             {
                 "device": [
                     "Dell Chromebook 3120 2-in-1"
                 ],
-                "boardname": [
-                    "ULDREN360"
-                ]
+                "boardname": "ULDREN360"
             },
             {
                 "device": [
                     "Asus Chromebook CR11 [CR1102C]"
                 ],
-                "boardname": [
-                    "XIVU"
-                ]
+                "boardname": "XIVU"
             },
             {
                 "device": [
                     "Asus Chromebook CR11 [CR1102F]"
                 ],
-                "boardname": [
-                    "XIVU360"
-                ]
+                "boardname": "XIVU360"
             },
             {
                 "device": [
                     "HP Chromebook Plus 14a"
                 ],
-                "boardname": [
-                    "YAHIKO"
-                ]
+                "boardname": "YAHIKO"
             },
             {
                 "device": [
                     "HP Fortis 14 inch G11 Chromebook"
                 ],
-                "boardname": [
-                    "YAVIJO"
-                ]
+                "boardname": "YAVIJO"
             },
             {
                 "device": [
                     "HP Chromebook 15a-nb0"
                 ],
-                "boardname": [
-                    "YAVIKS"
-                ]
+                "boardname": "YAVIKS"
             },
             {
                 "device": [
                     "HP Fortis 11 inch G10 Chromebook"
                 ],
-                "boardname": [
-                    "YAVILLA"
-                ]
+                "boardname": "YAVILLA"
             },
             {
                 "device": [
                     "HP Fortis x360 11 inch G5 Chromebook"
                 ],
-                "boardname": [
-                    "YAVILLY"
-                ]
+                "boardname": "YAVILLY"
             }
         ]
     },
@@ -2385,66 +1874,50 @@
                 "device": [
                     "Acer Chromebook 315 (CB315-2H)"
                 ],
-                "boardname": [
-                    "ALEENA"
-                ]
+                "boardname": "ALEENA"
             },
             {
                 "device": [
                     "HP Chromebook 11A G6 EE",
                     "HP Chromebook 11A G8 EE"
                 ],
-                "boardname": [
-                    "BARLA"
-                ]
+                "boardname": "BARLA"
             },
             {
                 "device": [
                     "HP Chromebook 14A G5"
                 ],
-                "boardname": [
-                    "CAREENA"
-                ]
+                "boardname": "CAREENA"
             },
             {
                 "device": [
                     "Acer Chromebook 311 (C721)"
                 ],
-                "boardname": [
-                    "KASUMI"
-                ]
+                "boardname": "KASUMI"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 311 (R721T)"
                 ],
-                "boardname": [
-                    "KASUMI360"
-                ]
+                "boardname": "KASUMI360"
             },
             {
                 "device": [
                     "Lenovo 14e Chromebook (S345)"
                 ],
-                "boardname": [
-                    "LIARA"
-                ]
+                "boardname": "LIARA"
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook Gen 2 AMD"
                 ],
-                "boardname": [
-                    "TREEYA"
-                ]
+                "boardname": "TREEYA"
             },
             {
                 "device": [
                     "Lenovo 300e Chromebook Gen 2 AMD"
                 ],
-                "boardname": [
-                    "TREEYA360"
-                ]
+                "boardname": "TREEYA360"
             }
         ]
     },
@@ -2458,82 +1931,62 @@
                     "HP Pro c645 Chromebook Enterprise",
                     "HP Chromebook 14b-na0"
                 ],
-                "boardname": [
-                    "BERKNIP"
-                ]
+                "boardname": "BERKNIP"
             },
             {
                 "device": [
                     "HP Chromebook 14a-nd0"
                 ],
-                "boardname": [
-                    "DIRINBOZ"
-                ]
+                "boardname": "DIRINBOZ"
             },
             {
                 "device": [
                     "Acer Chromebook Spin 514 (CP514-1H, CP514-1W)"
                 ],
-                "boardname": [
-                    "EZKINIL"
-                ]
+                "boardname": "EZKINIL"
             },
             {
                 "device": [
                     "HP Chromebook x360 14a-cb0"
                 ],
-                "boardname": [
-                    "GUMBOZ"
-                ]
+                "boardname": "GUMBOZ"
             },
             {
                 "device": [
                     "Asus Chromebook Flip CM1"
                 ],
-                "boardname": [
-                    "JELBOZ360"
-                ]
+                "boardname": "JELBOZ360"
             },
             {
                 "device": [
                     "Lenovo ThinkPad C13 Yoga Chromebook"
                 ],
-                "boardname": [
-                    "MORPHIUS"
-                ]
+                "boardname": "MORPHIUS"
             },
             {
                 "device": [
                     "Lenovo 100e Chromebook Gen 3"
                 ],
-                "boardname": [
-                    "VILBOZ"
-                ]
+                "boardname": "VILBOZ"
             },
             {
                 "device": [
                     "Lenovo 14e Chromebook Gen 2"
                 ],
-                "boardname": [
-                    "VILBOZ14"
-                ]
+                "boardname": "VILBOZ14"
             },
             {
                 "device": [
                     "Lenovo 300e Chromebook Gen 3",
                     "NEC Chromebook Y1 Gen3A"
                 ],
-                "boardname": [
-                    "VILBOZ360"
-                ]
+                "boardname": "VILBOZ360"
             },
             {
                 "device": [
                     "Asus Chromebook Flip CM5"
                 ],
-                "boardname": [
-                    "WOOMAX"
-                ]
+                "boardname": "WOOMAX"
             }
         ]
     },
@@ -2546,17 +1999,13 @@
                 "device": [
                     "Acer Chromebook Spin 514 [CP514-3H, CP514-3HH, CP514-3WH]"
                 ],
-                "boardname": [
-                    "DEWATT"
-                ]
+                "boardname": "DEWATT"
             },
             {
                 "device": [
                     "HP Elite c645 G2 Chromebook"
                 ],
-                "boardname": [
-                    "NIPPERKIN"
-                ]
+                "boardname": "NIPPERKIN"
             }
         ]
     },
@@ -2569,33 +2018,25 @@
                 "device": [
                     "TBD"
                 ],
-                "boardname": [
-                    "CRYSTALDRIFT"
-                ]
+                "boardname": "CRYSTALDRIFT"
             },
             {
                 "device": [
                     "Asus Chromebook CM34 Flip"
                 ],
-                "boardname": [
-                    "FROSTFLOW"
-                ]
+                "boardname": "FROSTFLOW"
             },
             {
                 "device": [
                     "Acer Chromebook Plus 514 (CB514-3H, CB514-3HT)"
                 ],
-                "boardname": [
-                    "MARKARTH"
-                ]
+                "boardname": "MARKARTH"
             },
             {
                 "device": [
                     "Dell Latitude 3445 Chromebook"
                 ],
-                "boardname": [
-                    "WHITERUN"
-                ]
+                "boardname": "WHITERUN"
             }
         ]
     }

--- a/supported-devices/devices.json
+++ b/supported-devices/devices.json
@@ -23,7 +23,7 @@
                     "Samsung Chromebook Series 5 550"
                 ],
                 "boardname": "LUMPY",
-		"wpMethod": "<a href=\"/images/wp/Lumpy_wp_jumper.jpg\" class=\"internal\" title=\"Lumpy_wp_jumper.jpg\" target=\"_blank\">jumper</a>"
+                "wpMethod": "<a href=\"/images/wp/Lumpy_wp_jumper.jpg\" class=\"internal\" title=\"Lumpy_wp_jumper.jpg\" target=\"_blank\">jumper</a>"
             },
             {
                 "device": [
@@ -44,7 +44,7 @@
                     "Samsung Chromebox Series 3"
                 ],
                 "boardname": "STUMPY",
-		"wpMethod": "screw"
+                "wpMethod": "screw"
             }
         ]
     },
@@ -71,7 +71,7 @@
                 "device": [
                     "Acer Chromebox CXI"
                 ],
-                "boardname": "McCLOUD",
+                "boardname": "MCCLOUD",
                 "wpMethod": "<a href=\"/images/wp/mccloud_wp.jpg\" class=\"internal\" title=\"mccloud_wp.jpg\" target=\"_blank\">screw</a>"
             },
             {
@@ -125,18 +125,6 @@
         "devices": [
             {
                 "device": [
-                    "Acer C740 Chromebook"
-                ],
-                "boardname": "AURON_PAINE"
-            },
-            {
-                "device": [
-                    "Acer C910 Chromebook (CB5-571)"
-                ],
-                "boardname": "AURON_YUNA"
-            },
-            {
-                "device": [
                     "Acer Chromebase 24"
                 ],
                 "boardname": "BUDDY",
@@ -144,7 +132,7 @@
             },
             {
                 "device": [
-                    "Toshiba Chromebook2 (2015)"
+                    "Toshiba Chromebook 2 (2015)"
                 ],
                 "boardname": "GANDOF",
                 "wpMethod": "screw"
@@ -161,6 +149,12 @@
                     "Dell Chromebook 13 7310"
                 ],
                 "boardname": "LULU"
+            },
+            {
+                "device": [
+                    "Acer C740 Chromebook"
+                ],
+                "boardname": "PAINE"
             },
             {
                 "device": [
@@ -182,6 +176,12 @@
                 ],
                 "boardname": "TIDUS",
                 "wpMethod": "<a href=\"/images/wp/tidus_wp.jpg\" class=\"internal\" title=\"tidus_wp.jpg\" target=\"_blank\">screw</a>"
+            },
+            {
+                "device": [
+                    "Acer C910 Chromebook (CB5-571)"
+                ],
+                "boardname": "YUNA"
             }
         ]
     },
@@ -210,6 +210,7 @@
             },
             {
                 "device": [
+                    "CTL N6 Education Chromebook",
                     "Lenovo N21 Chromebook"
                 ],
                 "boardname": "ENGUARDE"
@@ -350,16 +351,11 @@
             },
             {
                 "device": [
-                    "Asus Chromebook C202S/C202SA"
+                    "Asus Chromebook C202S/C202SA",
+                    "Asus Chromebook C300SA/C301SA"
                 ],
                 "boardname": "TERRA",
                 "wpMethod": "<a href=\"/images/wp/C202sa_wp.jpg\" class=\"internal\" title=\"C202sa wp.jpg\" target=\"_blank\">screw</a>"
-            },
-            {
-                "device": [
-                    "Asus Chromebook C300SA/C301SA"
-                ],
-                "boardname": "TERRA13"
             },
             {
                 "device": [
@@ -476,13 +472,13 @@
             },
             {
                 "device": [
-                    "Acer Chromebook 514"
+                    "Acer Chromebook 514 (CB514-1H, CB514-1HT)"
                 ],
                 "boardname": "EPAULETTE"
             },
             {
                 "device": [
-                    "Acer Chromebook Spin 11 CP311"
+                    "Acer Chromebook Spin 11 (CP311-1H, CP311-1HN)"
                 ],
                 "boardname": "LAVA"
             },
@@ -532,13 +528,13 @@
             },
             {
                 "device": [
-                    "Acer Chromebook 15 (CB515-1HT)"
+                    "Acer Chromebook 15 (CB515-1H, CB515-1HT)"
                 ],
                 "boardname": "SAND"
             },
             {
                 "device": [
-                    "Acer Chromebook 11 (CB311-8H)"
+                    "Acer Chromebook 11 (CB311-8H, CB311-8HT)"
                 ],
                 "boardname": "SANTA"
             },
@@ -569,13 +565,13 @@
         "devices": [
             {
                 "device": [
-                    "Acer Chromebook 13"
+                    "Acer Chromebook 13 (CB713-1W)"
                 ],
                 "boardname": "AKALI"
             },
             {
                 "device": [
-                    "Acer Chromebook Spin 13"
+                    "Acer Chromebook Spin 13 (CP713-1WN)"
                 ],
                 "boardname": "AKALI360"
             },
@@ -756,7 +752,7 @@
             },
             {
                 "device": [
-                    "Acer Chromebook 315"
+                    "Acer Chromebook 315 (CB315-3H, CB315-3HT)"
                 ],
                 "boardname": "BLORB"
             },
@@ -800,7 +796,7 @@
             },
             {
                 "device": [
-                    "Acer Chromebook 314 (CB314)",
+                    "Acer Chromebook 314 (C933, C933T, CB314-1H, CB314-1HT)",
                     "Packard Bell Chromebook 314 (PCB314)"
                 ],
                 "boardname": "DROID"
@@ -869,31 +865,14 @@
             },
             {
                 "device": [
-                    "Acer Chromebook 311"
-                ],
-                "boardname": "GLK"
-            },
-            {
-                "device": [
-                    "Acer Chromebook Spin 311"
-                ],
-                "boardname": "GLK360"
-            },
-            {
-                "device": [
                     "Dell Chromebook 3100 2-in-1"
                 ],
                 "boardname": "GRABBITER"
             },
             {
                 "device": [
-                    "Lenovo Chromebook C340"
-                ],
-                "boardname": "LASER"
-            },
-            {
-                "device": [
-                    "Lenovo Chromebook S340/IdeaPad 3"
+                    "Lenovo Chromebook S340",
+                    "Lenovo IdeaPad Flex 3 Chromebook 14\""
                 ],
                 "boardname": "LASER14"
             },
@@ -935,16 +914,13 @@
             },
             {
                 "device": [
-                    "Lenovo 300e Chromebook Gen 2/IdeaPad Flex 3",
+                    "Lenovo 300e Chromebook Gen 2",
+                    "Lenovo 500e Chromebook Gen 2",
+                    "Lenovo Chromebook C340",
+                    "Lenovo IdeaPad Flex 3 Chromebook 11\"",
                     "NEC Chromebook Y1"
                 ],
                 "boardname": "PHASER360"
-            },
-            {
-                "device": [
-                    "Lenovo 500e Chromebook Gen 2"
-                ],
-                "boardname": "PHASER360S"
             },
             {
                 "device": [
@@ -1029,6 +1005,13 @@
                     "Dell Latitude 7410 Chromebook Enterprise"
                 ],
                 "boardname": "DRALLION",
+                "rwLegacy": true
+            },
+            {
+                "device": [
+                    "Dell Latitude 7410 2-in-1 Chromebook Enterprise"
+                ],
+                "boardname": "DRALLION360",
                 "rwLegacy": true
             },
             {
@@ -1188,7 +1171,7 @@
             },
             {
                 "device": [
-                    "Acer Chromebook Spin 514 (CB514-2H)"
+                    "Acer Chromebook Spin 514 (CP514-2H)"
                 ],
                 "boardname": "VOEMA"
             },
@@ -1407,7 +1390,7 @@
             },
             {
                 "device": [
-                    "Acer Chromebook Spin 314"
+                    "Acer Chromebook Spin 314 [CP314-1H, CP314-1HN]"
                 ],
                 "boardname": "MAGISTER"
             },
@@ -1640,21 +1623,22 @@
                     "Acer Chromebook Plus 515 (CB515-2H, CB515-2HT)"
                 ],
                 "boardname": "OMNIGUL",
-				"wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
+                "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
             },
             {
                 "device": [
-                    "Acer Chromebook Plus Enterprise 515"
+                    "Acer Chromebook Plus Enterprise 515 (CBE595-2/CBE595-2T)"
                 ],
                 "boardname": "ONMIKNIGHT",
-				"wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
+                "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
             },
             {
                 "device": [
-                    "Acer Chromebook 516 GE [CBG516-1H]"
+                    "Acer Chromebook 516 GE [CBG516-1H]",
+                    "Acer Chromebook Plus 516 GE [CBG516-2H]"
                 ],
                 "boardname": "OSIRIS",
-				"wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
+                "wpMethod": "<a href=\"https://docs.mrchromebox.tech/docs/firmware/wp/disabling.html\" title=\"Firmware Write Protect\">CR50 (battery)</a>"
             },
             {
                 "device": [
@@ -1694,7 +1678,7 @@
             },
             {
                 "device": [
-                    "Acer Chromebook Vero 514"
+                    "Acer Chromebook Vero 514 (CBV514-1H, CBV514-1HT)"
                 ],
                 "boardname": "VOLMAR"
             },
@@ -1725,43 +1709,45 @@
             },
             {
                 "device": [
+                    "Acer Chromebook Spin 512 (R856T, R856LT)"
+                ],
+                "boardname": "CRAASK"
+            },
+            {
+                "device": [
                     "Acer Chromebook 311"
                 ],
                 "boardname": "CRAASKANA"
             },
             {
                 "device": [
-                    "Acer Chromebook Spin 511"
+                    "Acer Chromebook Spin 511 (R756T, R756LT)"
                 ],
                 "boardname": "CRAASKBOWL"
             },
             {
                 "device": [
-                    "Acer Chromebook Spin 512"
-                ],
-                "boardname": "CRAASK"
-            },
-            {
-                "device": [
-                    "Acer Chromebook 315 [CB315-5H]"
+                    "Acer Chromebook 315 (CB315-5H, CB315-5HT)"
                 ],
                 "boardname": "CRAASKINO"
             },
             {
                 "device": [
-                    "Acer Chromebook 511"
+                    "Acer Chromebook 511 (C736, C736T, C736L, C736LT)"
                 ],
                 "boardname": "CRAASKVIN"
             },
             {
                 "device": [
-                    "Acer Chromebook 314"
+                    "Acer Chromebook 314 (C936, C936T)",
+                    "Acer Chromebook 314 (CB314-4H, CB314-4HT)",
+                    "Acer Chromebook Plus 514 (CB514-4H, CB514-4HT)"
                 ],
                 "boardname": "CRAASNETO"
             },
             {
                 "device": [
-                    "Acer Chromebook Spin 314"
+                    "Acer Chromebook Spin 314 (CP314-2H, CP314-2HN)"
                 ],
                 "boardname": "CRAASWELL"
             },
@@ -1773,21 +1759,16 @@
             },
             {
                 "device": [
-                    "Lenovo 500e Yoga Chromebook Gen 4"
-                ],
-                "boardname": "PUJJO1E"
-            },
-            {
-                "device": [
-                    "Lenovo Flex 3i Chromebook 12\""
+                    "Lenovo 500e Yoga Chromebook Gen 4",
+                    "Lenovo Flex 3i Chromebook 12\" / IdeaPad Flex 3i Chromebook 12\""
                 ],
                 "boardname": "PUJJO"
             },
             {
                 "device": [
-                    "Lenovo IdeaPad Flex 3i Chromebook"
+                    "Lenovo 100e Chromebook Gen 4"
                 ],
-                "boardname": "PUJJOFLEX"
+                "boardname": "PUJJO1E"
             },
             {
                 "device": [
@@ -1945,7 +1926,7 @@
             },
             {
                 "device": [
-                    "Acer Chromebook Spin 514 (CP514-1W)"
+                    "Acer Chromebook Spin 514 (CP514-1H, CP514-1W)"
                 ],
                 "boardname": "EZKINIL"
             },
@@ -2032,7 +2013,7 @@
             },
             {
                 "device": [
-                    "Acer Chromebook Plus 514"
+                    "Acer Chromebook Plus 514 (CB514-3H, CB514-3HT)"
                 ],
                 "boardname": "MARKARTH"
             },

--- a/supported-devices/index.js
+++ b/supported-devices/index.js
@@ -66,7 +66,6 @@ function generateHTML(chromebooks) {
 
         devices.devices.forEach((device, index) => {
             let devicename = device.device.join("<br>");
-            let boardname = device.boardname.join("<br>");
             let rw_legacy = "";
             if (device.rwLegacy === null) {
                 rw_legacy = "<span style=\"color:#ff0000\"><b>EOL</b></span>";
@@ -79,7 +78,7 @@ function generateHTML(chromebooks) {
             html += `
         <tr>
             <td>${devicename}</td>
-            <td style="text-align:center;"> ${boardname}</td>
+            <td style="text-align:center;"> ${device.boardname}</td>
             <td style="text-align:center;"> ${rw_legacy}</td>
             <td style="text-align:center;"> ${full_rom}</td>
             <td style="text-align:center;"> ${device.wpMethod}</td>

--- a/supported-devices/index.js
+++ b/supported-devices/index.js
@@ -66,6 +66,7 @@ function generateHTML(chromebooks) {
 
         devices.devices.forEach((device, index) => {
             let devicename = device.device.join("<br>");
+            let boardname = device.boardname.join("<br>");
             let rw_legacy = "";
             if (device.rwLegacy === null) {
                 rw_legacy = "<span style=\"color:#ff0000\"><b>EOL</b></span>";
@@ -78,7 +79,7 @@ function generateHTML(chromebooks) {
             html += `
         <tr>
             <td>${devicename}</td>
-            <td style="text-align:center;"> ${device.boardname}</td>
+            <td style="text-align:center;"> ${boardname}</td>
             <td style="text-align:center;"> ${rw_legacy}</td>
             <td style="text-align:center;"> ${full_rom}</td>
             <td style="text-align:center;"> ${device.wpMethod}</td>


### PR DESCRIPTION
This fixes some HWIDs according to [recovery2.json](https://dl.google.com/dl/edgedl/chromeos/recovery/recovery2.json), notably:
- McCLOUD -> MCCLOUD
- AURON_PAINE -> PAINE
- AURON_YUNA -> YUNA
- TERRA13 -> merged with TERRA
- removed GLK, GLK360
- LASER -> merged with PHASER360
- PHASER360S -> merged with PHASER360
- added DRALLION360
- PUJJOFLEX -> merged with PUJJO

The following changes may also need to be made in the future, but they are still in recovery2.json for the time being:
- TARLO -> merge with TAEKO
- PUJJOTEEN15W -> merge with PUJJOTEEN

This PR also fixes/clarifies some device names.