### PR TITLE
build(deps): bump js-yaml override to 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5964,9 +5964,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "esbuild": "0.28.1",
     "gray-matter": "github:erikzaadi/gray-matter#ba2bc22b06834a2878d55b75312d20e9f39448e8",
     "http-proxy-middleware": "3.0.7",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "launch-editor": "2.14.1",
     "serialize-javascript": "^7.0.5",
     "uuid": "14.0.0",


### PR DESCRIPTION
## Summary
- Bumps the `js-yaml` npm override from `4.2.0` to `4.3.0` to fix [Dependabot alert #74](https://github.com/MrChromebox/website/security/dependabot/74) (GHSA-52cp-r559-cp3m / CVE-2026-59869).
- Regenerates `package-lock.json` so the resolved transitive dependency is `4.3.0`.

## Test plan
- [x] `npm ls js-yaml` shows `4.3.0`
- [ ] Site build (`npm run build`) still succeeds
- [ ] Dependabot alert #74 closes after merge
