### PR TITLE
build(deps): bump webpack-dev-server override to 5.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10508,9 +10508,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10532,7 +10532,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "launch-editor": "2.14.1",
     "serialize-javascript": "^7.0.5",
     "uuid": "14.0.0",
-    "webpack-dev-server": "5.2.5"
+    "webpack-dev-server": "5.2.6"
   },
   "devDependencies": {
     "@vuepress/bundler-webpack": "2.0.0-rc.30",


### PR DESCRIPTION
## Summary
- Bumps the `webpack-dev-server` npm override from `5.2.5` to `5.2.6` to fix [Dependabot alert #76](https://github.com/MrChromebox/website/security/dependabot/76) (GHSA-m28w-2pqf-7qgj) and [#77](https://github.com/MrChromebox/website/security/dependabot/77) (GHSA-f5vj-f2hx-8m93).
- Regenerates `package-lock.json` so the resolved dependency is `5.2.6`.

## Test plan
- [x] `npm ls webpack-dev-server` shows `5.2.6`
- [ ] Site build / `npm run dev` still works
- [ ] Dependabot alerts #76 and #77 close after merge
