### PR TITLE
build(deps): bump js-yaml override to 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5964,9 +5964,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "esbuild": "0.28.1",
     "gray-matter": "github:erikzaadi/gray-matter#ba2bc22b06834a2878d55b75312d20e9f39448e8",
     "http-proxy-middleware": "3.0.7",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "launch-editor": "2.14.1",
     "serialize-javascript": "^7.0.5",
     "uuid": "14.0.0",


### PR DESCRIPTION
## Summary
- Bumps the `js-yaml` npm override from `4.3.0` to `4.3.1` to fix [Dependabot alert #91](https://github.com/MrChromebox/website/security/dependabot/91) (GHSA-5p4m-2wfm-xmqj).
- Regenerates `package-lock.json` so the resolved transitive dependency is `4.3.1`.

## Test plan
- [x] `npm ls js-yaml` shows `4.3.1`
- [ ] Site build (`npm run build`) still succeeds
- [ ] Dependabot alert #91 closes after merge
