### PR TITLE
build(deps-dev): bump fast-uri from 3.1.4 to 3.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4885,9 +4885,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Bumps transitive `fast-uri` from `3.1.4` to `3.1.5` to fix [Dependabot alert #90](https://github.com/MrChromebox/website/security/dependabot/90) (GHSA-7p8r-x3mc-p8w7).
- Lockfile-only change (same approach as prior `fast-uri` Dependabot bumps).

## Test plan
- [x] `npm ls fast-uri` shows `3.1.5`
- [ ] Site build (`npm run build`) still succeeds
- [ ] Dependabot alert #90 closes after merge
